### PR TITLE
Renamed some theme props and introduced a hasBorderRadius on Card

### DIFF
--- a/src/app/components/atoms/Card/Card.js
+++ b/src/app/components/atoms/Card/Card.js
@@ -3,8 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { StyledCard } from './Card.sc';
 
-const Card = ({ children, elevation, position }) => (
-    <StyledCard elevation={elevation} position={position}>
+const Card = ({
+    children,
+    elevation,
+    hasBorderRadius,
+    position,
+}) => (
+    <StyledCard elevation={elevation} hasBorderRadius={hasBorderRadius} position={position}>
         {children}
     </StyledCard>
 );
@@ -15,11 +20,14 @@ Card.positions = CARD_POSITIONS;
 Card.propTypes = {
     children: PropTypes.node.isRequired,
     elevation: PropTypes.oneOf(Object.values(Card.elevations)),
+    // This is used in CardStatus to be able to remove the borderradius when a wrapper is applied
+    hasBorderRadius: PropTypes.bool,
     position: PropTypes.oneOf(Object.values(Card.positions)),
 };
 
 Card.defaultProps = {
     elevation: Card.elevations.LEVEL_1,
+    hasBorderRadius: true,
     position: Card.positions.TOP_LEFT,
 };
 

--- a/src/app/components/atoms/Card/Card.sc.js
+++ b/src/app/components/atoms/Card/Card.sc.js
@@ -1,22 +1,29 @@
 import { availableTextStyles, textStyling } from '../../../styles/theme/textStyles';
 import { backgroundColorPrimary, colorPrimary } from '../../../styles/theme/theme';
+import { borderRadius, spacingUnit } from '../../../styles/theme/layout';
+import styled, { css } from 'styled-components';
 import getElevation from '../../../styles/mixins/getElevation';
 import getPosition from '../../../styles/mixins/getPosition';
+import PropTypes from 'prop-types';
 import setBoxSizing from '../../../styles/mixins/setBoxSizing';
-import { spacingUnit } from '../../../styles/theme/layout';
-import styled from 'styled-components';
 
 export const StyledCard = styled.div`
     ${setBoxSizing()};
     ${textStyling(availableTextStyles().body1)};
     ${({ position }) => getPosition(position)};
     ${({ elevation }) => getElevation(elevation)};
+    ${({ hasBorderRadius }) => hasBorderRadius && css`
+        border-radius: calc(${borderRadius} / 2);
+    `}
     display: flex;
-    border-radius: 4px;
     background-color: ${backgroundColorPrimary};
     padding: ${spacingUnit};
     word-break: break-word;
     color: ${colorPrimary};
 `;
+
+StyledCard.propTypes = {
+    hasBorderRadius: PropTypes.bool.isRequired,
+};
 
 export default StyledCard;

--- a/src/app/components/atoms/Card/Card.stories.js
+++ b/src/app/components/atoms/Card/Card.stories.js
@@ -1,4 +1,4 @@
-import { select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import Button from '../../molecules/Button/Button';
 import Card from './Card';
 import React from 'react';
@@ -8,6 +8,7 @@ export default { title: 'atoms/Card' };
 export const Configurable = () => (
     <Card
         elevation={select('Elevation', Card.elevations, Card.defaultProps.elevation)}
+        hasBorderRadius={boolean('Has border radius', Card.defaultProps.hasBorderRadius)}
         position={select('Position', Card.positions, Card.defaultProps.position)}
     >
         {text('Text', 'Configure me!')}
@@ -17,6 +18,7 @@ export const Configurable = () => (
 export const ConfigurableWithComponent = () => (
     <Card
         elevation={select('Elevation', Card.elevations, Card.defaultProps.elevation)}
+        hasBorderRadius={boolean('Has border radius', Card.defaultProps.hasBorderRadius)}
         position={select('Position', Card.positions, Card.defaultProps.position)}
     >
         <Button

--- a/src/app/components/atoms/ErrorMessage/ErrorMessage.sc.js
+++ b/src/app/components/atoms/ErrorMessage/ErrorMessage.sc.js
@@ -1,10 +1,10 @@
 import { availableTextStyles, textStyling } from '../../../styles/theme/textStyles';
-import { colorSignalError } from '../../../styles/theme/theme';
+import { colorError } from '../../../styles/theme/theme';
 import styled from 'styled-components';
 
 export const StyledErrorMessage = styled.div`
     ${textStyling(availableTextStyles().caption)};
-    color: ${colorSignalError};
+    color: ${colorError};
 `;
 
 export default StyledErrorMessage;

--- a/src/app/components/atoms/Label/Label.sc.js
+++ b/src/app/components/atoms/Label/Label.sc.js
@@ -3,10 +3,10 @@ import { black, grey100, white } from '../../../styles/colors/colors';
 import {
     colorBodyLight,
     colorDisabled,
+    colorError,
     colorPrimary,
     colorSecondary,
-    colorSignalError,
-    colorSignalValid,
+    colorValid,
     themeModes,
 } from '../../../styles/theme/theme';
 import styled, { css } from 'styled-components';
@@ -41,11 +41,11 @@ export const StyledLabel = styled.label`
     `};
 
     ${({ isValid }) => isValid && css`
-        color: ${colorSignalValid};
+        color: ${colorValid};
     `};
 
     ${({ hasError }) => hasError && css`
-        color: ${colorSignalError};
+        color: ${colorError};
     `};
 
     ${({ isDisabled }) => isDisabled && css`

--- a/src/app/components/atoms/StatusIndicator/StatusIndicator.sc.js
+++ b/src/app/components/atoms/StatusIndicator/StatusIndicator.sc.js
@@ -1,9 +1,9 @@
 import {
-    colorSignalDisabled,
-    colorSignalError,
-    colorSignalStandard,
-    colorSignalValid,
-    colorSignalWarning,
+    colorDisabled,
+    colorError,
+    colorPrimary,
+    colorValid,
+    colorWarning,
 } from '../../../styles/theme/theme';
 import {
     STATUS_INDICATOR_PLACEMENTS,
@@ -13,6 +13,8 @@ import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
 export const StyledStatusIndicator = styled.div`
+    border-radius: inherit;
+
     ${({ placement }) => css`
         border-${placement.toLowerCase()}: 8px solid;
     `};
@@ -22,23 +24,23 @@ export const StyledStatusIndicator = styled.div`
     `};
 
     ${({ status }) => status === STATUS_INDICATOR_STATUSES.DISABLED && css`
-        border-color: ${colorSignalDisabled};
+        border-color: ${colorDisabled};
     `};
 
     ${({ status }) => status === STATUS_INDICATOR_STATUSES.ERROR && css`
-        border-color: ${colorSignalError};
+        border-color: ${colorError};
     `};
 
     ${({ status }) => status === STATUS_INDICATOR_STATUSES.VALID && css`
-        border-color: ${colorSignalValid};
+        border-color: ${colorValid};
     `};
 
     ${({ status }) => status === STATUS_INDICATOR_STATUSES.DEFAULT && css`
-        border-color: ${colorSignalStandard};
+        border-color: ${colorPrimary};
     `};
 
     ${({ status }) => status === STATUS_INDICATOR_STATUSES.WARNING && css`
-        border-color: ${colorSignalWarning};
+        border-color: ${colorWarning};
     `};
 
 `;

--- a/src/app/components/molecules/CardStatus/CardStatus.js
+++ b/src/app/components/molecules/CardStatus/CardStatus.js
@@ -8,13 +8,14 @@ import { StyledCardStatusWrapper } from './CardStatus.sc';
 const CardStatus = ({
     children,
     elevation,
+    hasBorderRadius,
     placement,
     position,
     status,
 }) => (
-    <StyledCardStatusWrapper elevation={elevation}>
+    <StyledCardStatusWrapper elevation={elevation} hasBorderRadius={hasBorderRadius} placement={placement}>
         <StatusIndicator placement={placement} status={status}>
-            <Card elevation={Card.elevations.LEVEL_0} position={position}>
+            <Card elevation={Card.elevations.LEVEL_0} hasBorderRadius={false} position={position}>
                 {children}
             </Card>
         </StatusIndicator>
@@ -29,6 +30,7 @@ CardStatus.statuses = CARD_STATUS_STATUSES;
 CardStatus.propTypes = {
     children: PropTypes.node.isRequired,
     elevation: PropTypes.oneOf(Object.values(CardStatus.elevations)),
+    hasBorderRadius: PropTypes.bool,
     placement: PropTypes.oneOf(Object.values(CardStatus.placements)),
     position: PropTypes.oneOf(Object.values(CardStatus.positions)),
     status: PropTypes.oneOf(Object.values(CardStatus.statuses)),
@@ -36,6 +38,7 @@ CardStatus.propTypes = {
 
 CardStatus.defaultProps = {
     elevation: Card.defaultProps.elevation,
+    hasBorderRadius: false,
     placement: CardStatus.placements.TOP,
     position: Card.defaultProps.position,
     status: CardStatus.statuses.DEFAULT,

--- a/src/app/components/molecules/CardStatus/CardStatus.sc.js
+++ b/src/app/components/molecules/CardStatus/CardStatus.sc.js
@@ -1,8 +1,34 @@
+import styled, { css } from 'styled-components';
+import { borderRadius } from '../../../styles/theme/layout';
+import { CARD_STATUS_PLACEMENTS } from './CardStatus.consts';
 import getElevation from '../../../styles/mixins/getElevation';
-import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 export const StyledCardStatusWrapper = styled.div`
     ${({ elevation }) => getElevation(elevation)};
+
+    ${({ hasBorderRadius, placement }) => hasBorderRadius && css`
+        ${placement === CARD_STATUS_PLACEMENTS.BOTTOM && css`
+            border-radius: 0 0 calc(${borderRadius} / 2) calc(${borderRadius} / 2);
+        `};
+
+        ${placement === CARD_STATUS_PLACEMENTS.LEFT && css`
+            border-radius: calc(${borderRadius} / 2) 0 0 calc(${borderRadius} / 2);
+        `};
+
+        ${placement === CARD_STATUS_PLACEMENTS.RIGHT && css`
+            border-radius: 0 calc(${borderRadius} / 2) calc(${borderRadius} / 2) 0;
+        `};
+
+        ${placement === CARD_STATUS_PLACEMENTS.TOP && css`
+            border-radius: calc(${borderRadius} / 2) calc(${borderRadius} / 2) 0 0;
+        `};
+    `};
 `;
+
+StyledCardStatusWrapper.propTypes = {
+    hasBorderRadius: PropTypes.bool.isRequired,
+    placement: PropTypes.oneOf(Object.values(CARD_STATUS_PLACEMENTS)).isRequired,
+};
 
 export default StyledCardStatusWrapper;

--- a/src/app/components/molecules/CardStatus/CardStatus.stories.js
+++ b/src/app/components/molecules/CardStatus/CardStatus.stories.js
@@ -1,4 +1,4 @@
-import { select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import Button from '../Button/Button';
 import CardStatus from './CardStatus';
 import React from 'react';
@@ -8,6 +8,7 @@ export default { title: 'molecules/CardStatus' };
 export const Configurable = () => (
     <CardStatus
         elevation={select('Elevation', CardStatus.elevations, CardStatus.defaultProps.elevation)}
+        hasBorderRadius={boolean('Has border radius', CardStatus.defaultProps.hasBorderRadius)}
         placement={select(
             'Status placement',
             CardStatus.placements,
@@ -23,6 +24,7 @@ export const Configurable = () => (
 export const ConfigurableWithComponent = () => (
     <CardStatus
         elevation={select('Elevation', CardStatus.elevations, CardStatus.defaultProps.elevation)}
+        hasBorderRadius={boolean('Has border radius', CardStatus.defaultProps.hasBorderRadius)}
         placement={select(
             'Status placement',
             CardStatus.placements,

--- a/src/app/components/molecules/Dropdown/Dropdown.sc.js
+++ b/src/app/components/molecules/Dropdown/Dropdown.sc.js
@@ -4,10 +4,10 @@ import {
     colorBodyDark,
     colorBodyLight,
     colorDisabled,
+    colorError,
     colorPrimaryHover,
     colorPrimarySelected,
-    colorSignalError,
-    colorSignalValid,
+    colorValid,
 } from '../../../styles/theme/theme';
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
@@ -28,11 +28,11 @@ export const StyledDropdown = styled.div`
         `};
 
         ${({ isValid }) => isValid && css`
-            background-color: ${colorSignalValid};
+            background-color: ${colorValid};
         `};
 
         ${({ hasError }) => hasError && css`
-            background-color: ${colorSignalError};
+            background-color: ${colorError};
         `};
 
         ${({ isDisabled }) => isDisabled && css`
@@ -76,13 +76,13 @@ export const Select = styled.select`
     `};
 
     ${({ isValid }) => isValid && css`
-        border-color: ${colorSignalValid};
-        color: ${colorSignalValid};
+        border-color: ${colorValid};
+        color: ${colorValid};
     `};
 
     ${({ hasError }) => hasError && css`
-        border-color: ${colorSignalError};
-        color: ${colorSignalError};
+        border-color: ${colorError};
+        color: ${colorError};
     `};
 
     ${({ isDisabled }) => isDisabled && css`
@@ -120,11 +120,11 @@ export const IconWrapper = styled.div`
     `};
 
     ${({ isValid }) => isValid && css`
-        color: ${colorSignalValid};
+        color: ${colorValid};
     `};
 
     ${({ hasError }) => hasError && css`
-        color: ${colorSignalError};
+        color: ${colorError};
     `};
 
     ${({ isDisabled }) => isDisabled && css`

--- a/src/app/components/molecules/Input/Input.sc.js
+++ b/src/app/components/molecules/Input/Input.sc.js
@@ -1,12 +1,12 @@
 import { availableTextStyles, textStyling } from '../../../styles/theme/textStyles';
 import {
     colorBodyDark,
+    colorDisabled,
+    colorError,
     colorPrimary,
     colorPrimaryHover,
     colorPrimarySelected,
-    colorSignalDisabled,
-    colorSignalError,
-    colorSignalValid,
+    colorValid,
 } from '../../../styles/theme/theme';
 import styled, { css } from 'styled-components';
 import { INPUT_VARIANTS } from '../../../utils/constants';
@@ -41,11 +41,11 @@ export const StyledInput = styled.div`
             `};
 
             ${isValid && css`
-                background-color: ${colorSignalValid};
+                background-color: ${colorValid};
             `};
 
             ${hasError && css`
-                background-color: ${colorSignalError};
+                background-color: ${colorError};
             `};
 
             ${isDisabled && css`
@@ -133,16 +133,16 @@ export const TextField = styled.input`
     `};
 
     ${({ isValid }) => isValid && css`
-        border-color: ${colorSignalValid};
+        border-color: ${colorValid};
     `};
 
     ${({ hasError }) => hasError && css`
-        border-color: ${colorSignalError};
+        border-color: ${colorError};
     `};
 
     ${({ isDisabled }) => isDisabled && css`
-        border-color: ${colorSignalDisabled};
-        color: ${colorSignalDisabled};
+        border-color: ${colorDisabled};
+        color: ${colorDisabled};
     `};
 `;
 

--- a/src/app/components/molecules/SelectionControl/SelectionControl.sc.js
+++ b/src/app/components/molecules/SelectionControl/SelectionControl.sc.js
@@ -1,9 +1,9 @@
 import {
     colorButtonLight,
+    colorDisabled,
+    colorError,
     colorPrimary,
-    colorSignalDisabled,
-    colorSignalError,
-    colorSignalValid,
+    colorValid,
     themeModes,
 } from '../../../styles/theme/theme';
 import {
@@ -77,26 +77,26 @@ export const InputWrapper = styled.div`
     `};
 
     ${({ isChecked, isIndeterminate, isValid }) => isValid && css`
-        border-color: ${colorSignalValid};
+        border-color: ${colorValid};
 
         ${(isChecked || isIndeterminate) && css`
-            background-color: ${colorSignalValid};
+            background-color: ${colorValid};
         `};
     `};
 
     ${({ hasError, isChecked, isIndeterminate }) => hasError && css`
-        border-color: ${colorSignalError};
+        border-color: ${colorError};
 
         ${(isChecked || isIndeterminate) && css`
-            background-color: ${colorSignalError};
+            background-color: ${colorError};
         `};
     `};
 
     ${({ isChecked, isDisabled, isIndeterminate }) => isDisabled && css`
-        border-color: ${colorSignalDisabled};
+        border-color: ${colorDisabled};
 
         ${(isChecked || isIndeterminate) && css`
-            background-color: ${colorSignalDisabled};
+            background-color: ${colorDisabled};
         `};
 
         input {

--- a/src/app/styles/theme/theme.js
+++ b/src/app/styles/theme/theme.js
@@ -26,7 +26,7 @@ export const fontSecondary = theme('mode', {
     [themeModes.light]: FONT_FAMILY_SECONDARY,
 });
 
-/* BASIC / ROOT */
+/* PRIMARY */
 export const colorPrimary = theme('mode', {
     [themeModes.basic]: colors.purple100,
     [themeModes.dark]: colors.white,
@@ -45,6 +45,13 @@ export const colorPrimarySelected = theme('mode', {
     [themeModes.light]: colors.grey25,
 });
 
+export const backgroundColorPrimary = theme('mode', {
+    [themeModes.basic]: colors.white,
+    [themeModes.dark]: colors.black,
+    [themeModes.light]: colors.white,
+});
+
+/* SECONDARY */
 export const colorSecondary = theme('mode', {
     [themeModes.basic]: colors.blue100,
     [themeModes.dark]: colors.grey2,
@@ -63,6 +70,13 @@ export const colorSecondarySelected = theme('mode', {
     [themeModes.light]: colors.grey25,
 });
 
+export const backgroundColorSecondary = theme('mode', {
+    [themeModes.basic]: colors.grey2,
+    [themeModes.dark]: colors.grey100,
+    [themeModes.light]: colors.grey2,
+});
+
+/* TERTIARY */
 export const colorTertiary = theme('mode', {
     [themeModes.basic]: colors.blue50,
     [themeModes.dark]: colors.grey2,
@@ -81,28 +95,35 @@ export const colorTertiarySelected = theme('mode', {
     [themeModes.light]: colors.grey25,
 });
 
+export const backgroundColorTertiary = theme('mode', {
+    [themeModes.basic]: colors.purple100,
+    [themeModes.dark]: colors.black,
+    [themeModes.light]: colors.white,
+});
+
+/* COLORS */
 export const colorDisabled = theme('mode', {
     [themeModes.basic]: colors.grey10,
     [themeModes.dark]: colors.grey10,
     [themeModes.light]: colors.grey10,
 });
 
-export const backgroundColorPrimary = theme('mode', {
-    [themeModes.basic]: colors.white,
-    [themeModes.dark]: colors.black,
-    [themeModes.light]: colors.white,
+export const colorError = theme('mode', {
+    [themeModes.basic]: colors.red,
+    [themeModes.dark]: colors.red,
+    [themeModes.light]: colors.red,
 });
 
-export const backgroundColorSecondary = theme('mode', {
-    [themeModes.basic]: colors.grey2,
-    [themeModes.dark]: colors.grey100,
-    [themeModes.light]: colors.grey2,
+export const colorValid = theme('mode', {
+    [themeModes.basic]: colors.green,
+    [themeModes.dark]: colors.green,
+    [themeModes.light]: colors.green,
 });
 
-export const backgroundColorTertiary = theme('mode', {
-    [themeModes.basic]: colors.purple100,
-    [themeModes.dark]: colors.black,
-    [themeModes.light]: colors.white,
+export const colorWarning = theme('mode', {
+    [themeModes.basic]: colors.orange,
+    [themeModes.dark]: colors.orange,
+    [themeModes.light]: colors.orange,
 });
 
 /* HEADERS / FOOTERS */
@@ -159,35 +180,4 @@ export const colorButtonLight = theme('mode', {
     [themeModes.basic]: colors.white,
     [themeModes.dark]: colors.white,
     [themeModes.light]: colors.black,
-});
-
-/* SIGNAL / ACCENT */
-export const colorSignalStandard = theme('mode', {
-    [themeModes.basic]: colors.purple100,
-    [themeModes.dark]: colors.purple100,
-    [themeModes.light]: colors.purple100,
-});
-
-export const colorSignalValid = theme('mode', {
-    [themeModes.basic]: colors.green,
-    [themeModes.dark]: colors.green,
-    [themeModes.light]: colors.green,
-});
-
-export const colorSignalWarning = theme('mode', {
-    [themeModes.basic]: colors.orange,
-    [themeModes.dark]: colors.orange,
-    [themeModes.light]: colors.orange,
-});
-
-export const colorSignalError = theme('mode', {
-    [themeModes.basic]: colors.red,
-    [themeModes.dark]: colors.red,
-    [themeModes.light]: colors.red,
-});
-
-export const colorSignalDisabled = theme('mode', {
-    [themeModes.basic]: colors.grey10,
-    [themeModes.dark]: colors.grey10,
-    [themeModes.light]: colors.grey10,
 });


### PR DESCRIPTION
Renamed some theme props and introduced a hasBorderRadius on Card level so we can unset borders in cardstatus.

Asked Marrick how to deal with the borderradius in cardstatus, because the design has none, but want to be sure. Hence the parameter.