### PR TITLE
property hasNoPadding, if false padding 0, otherwise padding 4px in t…

### DIFF
--- a/src/app/components/molecules/Button/Button.sc.ts
+++ b/src/app/components/molecules/Button/Button.sc.ts
@@ -5,6 +5,7 @@ import { themeBasic } from '../../../styles/theming/themes/basic';
 import { transitionEffect } from '../../../styles/mixins/transitionEffects';
 
 interface StyledButtonProps {
+    hasNoPadding: boolean;
     isDisabled: boolean;
     isFullWidth: boolean;
     isInverted: boolean;
@@ -132,13 +133,13 @@ export const StyledButton = styled.button<StyledButtonProps>`
             `}
         `}
 
-    ${({ isDisabled, isInverted, theme: { button }, variant }): SimpleInterpolation =>
+    ${({ hasNoPadding, isDisabled, isInverted, theme: { button }, variant }): SimpleInterpolation =>
         variant === ButtonVariant.TEXT_ONLY &&
         css`
             border: 0;
             border-radius: 0;
             background-color: transparent !important;
-            padding: 0;
+            padding: ${hasNoPadding ? 0 : '4px'};
             min-width: 0;
             min-height: 0;
             color: ${isInverted ? button.textOnly.inverted : button.textOnly.primary};

--- a/src/app/components/molecules/Button/Button.tsx
+++ b/src/app/components/molecules/Button/Button.tsx
@@ -9,6 +9,7 @@ export interface ButtonProps {
     children?: ReactNode;
     className?: string;
     direction?: Direction;
+    hasNoPadding?: boolean;
     iconType?: IconType;
     isCapitalized?: boolean;
     isDisabled?: boolean;
@@ -23,12 +24,12 @@ export interface ButtonProps {
     variant?: ButtonVariant;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const Button: FunctionComponent<ButtonProps & { [key: string]: any }> = ({
+export const Button: FunctionComponent<ButtonProps & { [key: string]: unknown }> = ({
     autoFocus = false,
     children,
     className,
     direction = Direction.LTR,
+    hasNoPadding = false,
     iconType,
     isCapitalized = true,
     isDisabled = false,
@@ -46,6 +47,7 @@ export const Button: FunctionComponent<ButtonProps & { [key: string]: any }> = (
     <StyledButton
         autoFocus={autoFocus}
         className={className}
+        hasNoPadding={hasNoPadding}
         isDisabled={isDisabled}
         isFullWidth={isFullWidth}
         isInverted={isInverted}


### PR DESCRIPTION
…ext-only buttons

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-550

**Description of the pull request**:
- property hasNoPadding, default false
- when hasNoPadding is true then the padding of a text-only button is 0, otherwise, it has padding of 4px all around.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
