### PR TITLE
do dockerhub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ references:
     container_config: &container_config
         docker:
             - image: circleci/node:10.16.0
+              auth:
+                  username: $DOCKERHUB_USER
+                  password: $DOCKERHUB_PASS
+
         working_directory: ~/dexels-ui-kit
     restore_dependencies: &restore_dependencies
         restore_cache:
@@ -60,10 +64,16 @@ jobs:
 workflows:
     install_dependencies_and_lint:
         jobs:
-            - install_dependencies
+            - install_dependencies:
+                context:
+                    - dexels_docker_hub
             - lint_javascript:
+                context:
+                    - dexels_docker_hub
                 requires:
                     - install_dependencies
             - lint_css:
+                context:
+                    - dexels_docker_hub
                 requires:
                     - install_dependencies


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://github.com/Dexels/dexels-base/issues/1

**Description of the pull request**:
Adds authentication annotations to circlecI configuration, in order to prevent failed build to to docker hub rate limiting


More info: 

"""
Hi there,

On November 1st, Docker Hub will begin limiting anonymous image pulls. We want to make sure you know how you might be impacted and what you can do to avoid interruptions to your workflow.

Adding Docker authentication to your pipeline config is the easiest way to avoid any service disruptions. If you use the Docker executor or pull Docker images when using the machine executor on CircleCI, we encourage you to authenticate. Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP.

We are currently working on a partnership with Docker to minimize the impact of this change for our users and will share more details as we get them.

For more information or to leave a question for us, please head over to Discuss or contact support.

Thanks and happy building,

The CircleCI team
"""

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />