### PR TITLE
CW-826 get the height of the dom element that is the calendar part of a date…

### DIFF
--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -80,17 +80,23 @@ export const SingleDatePicker: FunctionComponent<SingleDatePickerProps> = ({
     const singleDatePickerRef = useRef<HTMLDivElement>(null);
     const [openDirection, setOpenDirection] = useState<OpenDirectionShape>('down');
     const [isTopDatepicker, setIsTopDatepicker] = useState(false);
+    const [openDatePickerMinHeight, setOpenDatePickerMinHeight] = useState(400);
+
+    useEffect(() => {
+        // Get the height of de DOM element of the calendar part of a SingleDatePicker_picker
+        const datePickerContainer = document.querySelectorAll('div.DayPicker__horizontal');
+
+        if (
+            datePickerContainer &&
+            datePickerContainer.length !== 0 &&
+            datePickerContainer[0].clientHeight !== openDatePickerMinHeight
+        ) {
+            setOpenDatePickerMinHeight(datePickerContainer[0].clientHeight);
+        }
+    });
 
     useEffect(() => {
         if (singleDatePickerRef.current) {
-            // Get the height of de DOM element SingleDatePicker_picker
-            const datePickerContainer = document.querySelectorAll('div.SingleDatePicker_picker');
-            let openDatePickerMinHeight = 400;
-
-            if (datePickerContainer && datePickerContainer.length !== 0) {
-                openDatePickerMinHeight = datePickerContainer[0].clientHeight;
-            }
-
             let { top } = singleDatePickerRef.current.getBoundingClientRect();
 
             if (parentContainer) {


### PR DESCRIPTION
… picker, not just the input field

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-826

**Description of the pull request**:
it was the wrong dom element that was used for the calculation
the correct dom element is not always rendered. we need to check for every render if it is there and update a local state
the default of the local state is 400 px. 
if the actual height of the open date picker is different then the state variable is updated.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
