### PR TITLE
CW-799 add optional outOfRange function to editable datepicker

### DIFF
--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -84,6 +84,7 @@ export const editableData = <T extends DropdownSelectOption, U extends DropdownM
                             id={name}
                             isDisabled={isDisabled}
                             isFocused={datePickerFocuses[name]}
+                            isOutsideRange={dataInstance.isOutsideRange}
                             label={dataInstance.placeholder}
                             onDateChange={(date): void => {
                                 onChange(name, date);

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -167,9 +167,10 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
     result.push({
         component: EditableDataComponent.DATEPICKER,
         isEditable: true,
+        isOutsideRange: () => false,
         label: 'Editable Date',
         name: 'EditableDate',
-        value: moment(),
+        value: moment('1950-06-03'),
     } as EditableDatePickerDataProps);
 
     result.push({

--- a/src/app/components/organisms/EditableInformation/types.ts
+++ b/src/app/components/organisms/EditableInformation/types.ts
@@ -37,6 +37,7 @@ export interface DatePickerDataProps extends BaseDataProps {
 }
 
 export interface EditableDatePickerDataProps extends DatePickerDataProps {
+    isOutsideRange?: SingleDatePickerProps['isOutsideRange'];
     name: string;
     placeholder?: SingleDatePickerProps['label'];
 }


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
related to cards Member Person information - there we have dates back in the past like birth date and date start membership and the date picker won't show a range. the range should be given with a function (maybe a function that returns always false, so always not out of range and in other cases check the range so an instance in the editable data should have this optional function.

**Description of the pull request**:
*The PR description goes here*

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
