### PR TITLE
add optional onBlur props to editableInputData, for calculating addre…

### DIFF
--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -184,6 +184,11 @@ export const editableData = <T extends DropdownSelectOption, U extends DropdownM
                             onChange={({ currentTarget }): void => {
                                 onChange(currentTarget.name, currentTarget.value);
                             }}
+                            onFocus={(event): void => {
+                                if (dataInstance.onFocus) {
+                                    dataInstance.onFocus(event);
+                                }
+                            }}
                             type={dataInstance.type}
                             value={values[name] as string | undefined}
                             variant={InputVariant.COMPACT}

--- a/src/app/components/organisms/EditableInformation/types.ts
+++ b/src/app/components/organisms/EditableInformation/types.ts
@@ -111,6 +111,7 @@ export interface EditableInputDataProps extends InputDataProps {
     maxLength?: InputProps['maxLength'];
     name: InputProps['name'];
     onBlur?: InputProps['onBlur'];
+    onFocus?: InputProps['onFocus'];
     placeholder?: InputProps['label'];
     type?: InputProps['type'];
 }


### PR DESCRIPTION
…ss from zipcode number combination

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-835

**Description of the pull request**:
we need to give editable input an onBlur function in order to calculate the address when the fields zipcode  and address number are blured.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
