### PR TITLE
Added support for null values in Input component

### DIFF
--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -36,7 +36,7 @@ export interface InputProps {
     onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
     onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
     type?: InputType;
-    value?: string;
+    value?: string | null;
     variant?: InputVariant;
 }
 
@@ -68,7 +68,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
 }) => {
     const [isFocused, setIsFocused] = useState(false);
     const [isHovered, setIsHovered] = useState(false);
-    const hasValue = value.length > 0;
+    const hasValue = value ? value.length > 0 : false;
     const textFieldProps: { [key: string]: number } = {};
 
     const onChangeCallback = useCallback(
@@ -154,7 +154,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     onMouseEnter={isDisabled ? undefined : toggleIsHoveredCallback}
                     onMouseLeave={isDisabled ? undefined : toggleIsHoveredCallback}
                     type={type}
-                    value={value}
+                    value={value === null ? undefined : value} // Assuming that null equals undefined
                     variant={variant}
                     {...textFieldProps}
                 />

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -116,6 +116,16 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
     result.push({
         component: EditableDataComponent.INPUT,
         isDisabled: false,
+        isEditable: true,
+        isRequired: true,
+        label: 'Input (null value)',
+        name: 'InputNull',
+        value: null,
+    } as EditableInputDataProps);
+
+    result.push({
+        component: EditableDataComponent.INPUT,
+        isDisabled: false,
         isEditable: false,
         isRequired: true,
         label: 'Input (not editable)',


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
*https://jira.sportlink.nl/browse/CW-909*

**Description of the pull request**:
*- added support in Input (and EditableInformation) component for null values*

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
