### PR TITLE
change in props isEditing to cause re-render component for controling…

### DIFF
--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -69,14 +69,14 @@ export const EditableInformation = <T extends DropdownSelectOption, U extends Dr
     const [datePickerFocuses, setDatePickerFocuses] = useState<DatePickerFocuses>({});
     const hasError = errors !== undefined;
     const [informationTableData, setInformationTableData] = useState<InformationTableData[]>([]);
-    const [isBeingEdited, setIsBeingEdited] = useState(isEditing);
+    const [isBeingEdited, setIsBeingEdited] = useState(false);
     const [isEditable, setIsEditable] = useState<boolean>(false);
     const [originalValues, setOriginalValues] = useState<EditableDataProps<T, U>['values']>({});
     const [updatedValues, setUpdatedValues] = useState<EditableDataProps<T, U>['values']>({});
 
     useEffect(() => {
-        setIsBeingEdited(hasError);
-    }, [hasError]);
+        setIsBeingEdited(hasError || isEditing);
+    }, [hasError, isEditing]);
 
     const onEditCallback = useCallback(() => {
         setIsBeingEdited(true);


### PR DESCRIPTION
… edit-mode from outside too

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
for CW_833 and CW-833
It should be possible to stay in edit-mode even when clicking "save", for example when a dialog is shown.
making sure changes in props "isEditing" re-renders the Component with isEffect makes it possible to controll the edit-mode also from outside.


<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
