### PR TITLE
add props noResultsMessage to Table, icon optional by cardNoResults

### DIFF
--- a/src/app/components/molecules/CardNoResults/CardNoResults.stories.tsx
+++ b/src/app/components/molecules/CardNoResults/CardNoResults.stories.tsx
@@ -15,3 +15,13 @@ export const Configurable: FunctionComponent = () => (
         title={text('Title', 'Some title text')}
     />
 );
+
+export const ConfigurableWithoutIcon: FunctionComponent = () => (
+    <CardNoResults
+        elevation={select('Elevation', Elevation, Elevation.LEVEL_1)}
+        header={text('Header', 'Some header text')}
+        itemPrefix={text('Item prefix', '-')}
+        items={array('Items', ['Item 1', 'Item 2'])}
+        title={text('Title', 'Some title text')}
+    />
+);

--- a/src/app/components/molecules/CardNoResults/CardNoResults.tsx
+++ b/src/app/components/molecules/CardNoResults/CardNoResults.tsx
@@ -9,7 +9,7 @@ export interface CardNoResultsProps {
     className?: string;
     elevation?: Elevation;
     header: ReactNode;
-    iconType: IconType;
+    iconType?: IconType;
     itemPrefix?: string;
     items?: ReactNode[];
     title?: ReactNode;
@@ -25,11 +25,13 @@ export const CardNoResults: FunctionComponent<CardNoResultsProps> = ({
     title,
 }) => (
     <StyledCardNoResults className={className} elevation={elevation}>
-        <Left>
-            <IconWrapper>
-                <IconCustomizable iconSize={IconCustomizableSize.SIZE30} iconType={iconType} />
-            </IconWrapper>
-        </Left>
+        {iconType && (
+            <Left>
+                <IconWrapper>
+                    <IconCustomizable iconSize={IconCustomizableSize.SIZE30} iconType={iconType} />
+                </IconWrapper>
+            </Left>
+        )}
         <Right>
             <Header>{header}</Header>
             {title && <Title>{title}</Title>}

--- a/src/app/components/organisms/Table/Table.stories.tsx
+++ b/src/app/components/organisms/Table/Table.stories.tsx
@@ -28,10 +28,18 @@ export const Configurable: FunctionComponent = () => {
     const [isNL, setIsNL] = useState(true);
     const localizedTexts = createLocalizedTableTexts(isNL ? 'nl' : 'en');
     const [hasGroupHeader, setHasGroupHeader] = useState(false);
+    const [isEmpty, setIsEmpty] = useState(false);
     const [isFooterVisible, setIsFooterVisible] = useState(false);
-    const data = useMemo(() => tableData(), []);
     const columns = useMemo(() => tableColumns(), []);
     const columnsWithGroupHeader = useMemo(() => tableColumnsWithGroupHeader(), []);
+
+    const data = useMemo(() => {
+        if (isEmpty) {
+            return [] as TableData[];
+        }
+
+        return tableData();
+    }, [isEmpty]);
 
     const instance = createTable<TableData>(
         hasGroupHeader ? columnsWithGroupHeader : columns,
@@ -64,6 +72,15 @@ export const Configurable: FunctionComponent = () => {
                         setIsNL(!isNL);
                     }}
                     value="isNL"
+                />
+                <SelectionControl
+                    isChecked={isEmpty}
+                    label={isEmpty ? 'Empty table' : 'Not an empty table'}
+                    name="ISEMPTY   "
+                    onChange={(): void => {
+                        setIsEmpty(!isEmpty);
+                    }}
+                    value="isEmpty"
                 />
                 <SelectionControl
                     isChecked={hasGroupHeader}
@@ -104,6 +121,7 @@ export const Configurable: FunctionComponent = () => {
                     hasUnsortedStateIcon={boolean('Has unsorted state icon', true)}
                     instance={instance}
                     isFullWidth={boolean('Is full width', true)}
+                    noResultsMessage={text('No result message', 'No results found')}
                     onClickFooter={isFooterVisible ? getTableFooter : undefined}
                     onClickRow={getTableRow}
                     paginator={

--- a/src/app/components/organisms/Table/Table.tsx
+++ b/src/app/components/organisms/Table/Table.tsx
@@ -26,6 +26,8 @@ import {
 } from './Table.sc';
 import React, { ReactNode, SyntheticEvent } from 'react';
 import { Row, TableInstance } from 'react-table';
+import CardNoResults from '../../molecules/CardNoResults/CardNoResults';
+import { isEmpty } from '../../../utils/functions/validateFunctions';
 import { renderSortIcon } from './utils/tableFunctions';
 
 export interface TableTexts {
@@ -43,6 +45,7 @@ export interface TableProps<T extends object> {
     instance: TableInstance<T>;
     isDisabled?: boolean;
     isFullWidth?: boolean;
+    noResultsMessage?: string;
     onClickFooter?: (event: SyntheticEvent) => void;
     onClickRow?: (event: SyntheticEvent, row: Row<T>) => void;
     paginator?: ReactNode;
@@ -62,6 +65,7 @@ export const Table = <T extends object>({
     instance,
     isDisabled = false,
     isFullWidth = true,
+    noResultsMessage,
     onClickFooter,
     onClickRow,
     paginator,
@@ -69,156 +73,166 @@ export const Table = <T extends object>({
 }: TableProps<T>): JSX.Element => {
     const { footerGroups, getTableBodyProps, getTableProps, headerGroups, prepareRow } = instance;
     let hasFooterColumns = false;
+    const hasResults = instance.data.length !== 0;
 
     return (
         <>
             {caption && <TableCaption>{caption}</TableCaption>}
-            <TableWrapper>
-                <StyledTable className={className} isFullWidth={isFullWidth} {...getTableProps()}>
-                    <TableHead>
-                        {headerGroups.map((headerGroup) => (
-                            <TableHeaderRow {...headerGroup.getHeaderGroupProps()}>
-                                {headerGroup.headers
-                                    .filter(({ isVisible }) => isVisible)
-                                    .map((column) => (
-                                        <TableHeaderCell
-                                            {...column.getHeaderProps(
-                                                column.getSortByToggleProps({
-                                                    title: (texts && texts.sortByTooltip) || undefined,
-                                                })
-                                            )}
-                                            hasCellPadding={column.hasCellPadding}
-                                            isDisabled={isDisabled}
-                                            width={column.width}
-                                        >
-                                            <TableHeaderCellInner
-                                                align={column.align || Alignment.LEFT}
-                                                isSorted={column.isSorted}
-                                            >
-                                                <TableHeaderCellContent>
-                                                    {column.render('Header')}
-                                                </TableHeaderCellContent>
-                                                {column.canSort && renderSortIcon(column, hasUnsortedStateIcon)}
-                                            </TableHeaderCellInner>
-                                        </TableHeaderCell>
-                                    ))}
-                            </TableHeaderRow>
-                        ))}
-                    </TableHead>
-                    <TableBody elevation={elevation} {...getTableBodyProps()}>
-                        {/* USE A CONST (SEE TOP OF FILE) TO DETERMINE CORRECT DATA SOURCE FOR READING (PAGE OR ROWS) */}
-                        {dataSource(instance, Boolean(paginator)).map((row) => {
-                            prepareRow(row);
+            {!hasResults && !isEmpty(noResultsMessage) ? (
+                <CardNoResults header={noResultsMessage} title={''} />
+            ) : (
+                <>
+                    <TableWrapper>
+                        <StyledTable className={className} isFullWidth={isFullWidth} {...getTableProps()}>
+                            <TableHead>
+                                {headerGroups.map((headerGroup) => (
+                                    <TableHeaderRow {...headerGroup.getHeaderGroupProps()}>
+                                        {headerGroup.headers
+                                            .filter(({ isVisible }) => isVisible)
+                                            .map((column) => (
+                                                <TableHeaderCell
+                                                    {...column.getHeaderProps(
+                                                        column.getSortByToggleProps({
+                                                            title: (texts && texts.sortByTooltip) || undefined,
+                                                        })
+                                                    )}
+                                                    hasCellPadding={column.hasCellPadding}
+                                                    isDisabled={isDisabled}
+                                                    width={column.width}
+                                                >
+                                                    <TableHeaderCellInner
+                                                        align={column.align || Alignment.LEFT}
+                                                        isSorted={column.isSorted}
+                                                    >
+                                                        <TableHeaderCellContent>
+                                                            {column.render('Header')}
+                                                        </TableHeaderCellContent>
+                                                        {column.canSort && renderSortIcon(column, hasUnsortedStateIcon)}
+                                                    </TableHeaderCellInner>
+                                                </TableHeaderCell>
+                                            ))}
+                                    </TableHeaderRow>
+                                ))}
+                            </TableHead>
+                            <TableBody elevation={elevation} {...getTableBodyProps()}>
+                                {/* USE A CONST (SEE TOP OF FILE) TO DETERMINE CORRECT DATA SOURCE FOR READING (PAGE OR ROWS) */}
+                                {dataSource(instance, Boolean(paginator)).map((row) => {
+                                    prepareRow(row);
 
-                            return (
-                                <TableRow
-                                    isClickable={Boolean(onClickRow)}
+                                    return (
+                                        <TableRow
+                                            isClickable={Boolean(onClickRow)}
+                                            onClick={
+                                                onClickRow
+                                                    ? (event: SyntheticEvent): void => {
+                                                          onClickRow(event, row);
+                                                      }
+                                                    : undefined
+                                            }
+                                            {...row.getRowProps()}
+                                        >
+                                            {row.cells
+                                                .filter(({ column }) => column.isVisible)
+                                                .map((cell) => {
+                                                    // Check if we need to do some looping for the footer based on aggregate setting
+                                                    hasFooterColumns =
+                                                        hasFooterColumns || Boolean(cell.column.aggregate);
+
+                                                    return (
+                                                        <TableCell
+                                                            {...cell.getCellProps()}
+                                                            hasCellPadding={cell.column.hasCellPadding}
+                                                            isClickable={Boolean(cell.column.onClick)}
+                                                            onClick={(event: SyntheticEvent): void => {
+                                                                if (cell.column.onClick) {
+                                                                    event.stopPropagation();
+                                                                    cell.column.onClick(cell, row, event);
+                                                                }
+                                                            }}
+                                                            width={cell.column.width}
+                                                        >
+                                                            <TableCellContent
+                                                                align={cell.column.align || Alignment.LEFT}
+                                                            >
+                                                                {cell.isGrouped ? (
+                                                                    // If it's a grouped cell, add an expander and row count
+                                                                    <>
+                                                                        <span {...row.getToggleRowExpandedProps()}>
+                                                                            {row.isExpanded
+                                                                                ? IconType.ARROWDOWN
+                                                                                : IconType.ARROWRIGHT}
+                                                                        </span>{' '}
+                                                                        {cell.render('Cell', { editable: false })}
+                                                                    </>
+                                                                ) : cell.isAggregated ? (
+                                                                    // If the cell is aggregated, use the Aggregated
+                                                                    // renderer for cell
+                                                                    cell.render('Aggregated')
+                                                                ) : cell.isPlaceholder ? null : ( // For cells with repeated values, render null
+                                                                    // Otherwise, just render the regular cell
+                                                                    cell.render('Cell', { editable: true })
+                                                                )}
+                                                            </TableCellContent>
+                                                        </TableCell>
+                                                    );
+                                                })}
+                                        </TableRow>
+                                    );
+                                })}
+                            </TableBody>
+                            {hasFooterColumns && (
+                                <TableFooter elevation={elevation}>
+                                    {footerGroups.map((footerGroup) => (
+                                        <TableFooterRow {...footerGroup.getFooterGroupProps()}>
+                                            {footerGroup.headers
+                                                .filter(({ isVisible }) => isVisible)
+                                                .map(
+                                                    (column, index) =>
+                                                        (index === 0 || index >= footerTitleColumnSpan) && (
+                                                            <TableFooterCell
+                                                                {...column.getFooterProps()}
+                                                                // colSpan={index === 0 ? footerTitleColumnSpan : 1}
+                                                                hasCellPadding={column.hasCellPadding}
+                                                                isDisabled={isDisabled}
+                                                            >
+                                                                <TableFooterCellInner
+                                                                    align={column.align || Alignment.LEFT}
+                                                                    isSorted={column.isSorted}
+                                                                >
+                                                                    <TableFooterCellContent>
+                                                                        {column.aggregate
+                                                                            ? column.render('Aggregated')
+                                                                            : column.render('Footer')}
+                                                                    </TableFooterCellContent>
+                                                                </TableFooterCellInner>
+                                                            </TableFooterCell>
+                                                        )
+                                                )}
+                                        </TableFooterRow>
+                                    ))}
+                                </TableFooter>
+                            )}
+
+                            {footer && (
+                                <TableFooterComponent
+                                    elevation={elevation}
+                                    isClickable={Boolean(onClickFooter)}
                                     onClick={
-                                        onClickRow
+                                        onClickFooter
                                             ? (event: SyntheticEvent): void => {
-                                                  onClickRow(event, row);
+                                                  onClickFooter(event);
                                               }
                                             : undefined
                                     }
-                                    {...row.getRowProps()}
                                 >
-                                    {row.cells
-                                        .filter(({ column }) => column.isVisible)
-                                        .map((cell) => {
-                                            // Check if we need to do some looping for the footer based on aggregate setting
-                                            hasFooterColumns = hasFooterColumns || Boolean(cell.column.aggregate);
-
-                                            return (
-                                                <TableCell
-                                                    {...cell.getCellProps()}
-                                                    hasCellPadding={cell.column.hasCellPadding}
-                                                    isClickable={Boolean(cell.column.onClick)}
-                                                    onClick={(event: SyntheticEvent): void => {
-                                                        if (cell.column.onClick) {
-                                                            event.stopPropagation();
-                                                            cell.column.onClick(cell, row, event);
-                                                        }
-                                                    }}
-                                                    width={cell.column.width}
-                                                >
-                                                    <TableCellContent align={cell.column.align || Alignment.LEFT}>
-                                                        {cell.isGrouped ? (
-                                                            // If it's a grouped cell, add an expander and row count
-                                                            <>
-                                                                <span {...row.getToggleRowExpandedProps()}>
-                                                                    {row.isExpanded
-                                                                        ? IconType.ARROWDOWN
-                                                                        : IconType.ARROWRIGHT}
-                                                                </span>{' '}
-                                                                {cell.render('Cell', { editable: false })}
-                                                            </>
-                                                        ) : cell.isAggregated ? (
-                                                            // If the cell is aggregated, use the Aggregated
-                                                            // renderer for cell
-                                                            cell.render('Aggregated')
-                                                        ) : cell.isPlaceholder ? null : ( // For cells with repeated values, render null
-                                                            // Otherwise, just render the regular cell
-                                                            cell.render('Cell', { editable: true })
-                                                        )}
-                                                    </TableCellContent>
-                                                </TableCell>
-                                            );
-                                        })}
-                                </TableRow>
-                            );
-                        })}
-                    </TableBody>
-                    {hasFooterColumns && (
-                        <TableFooter elevation={elevation}>
-                            {footerGroups.map((footerGroup) => (
-                                <TableFooterRow {...footerGroup.getFooterGroupProps()}>
-                                    {footerGroup.headers
-                                        .filter(({ isVisible }) => isVisible)
-                                        .map(
-                                            (column, index) =>
-                                                (index === 0 || index >= footerTitleColumnSpan) && (
-                                                    <TableFooterCell
-                                                        {...column.getFooterProps()}
-                                                        // colSpan={index === 0 ? footerTitleColumnSpan : 1}
-                                                        hasCellPadding={column.hasCellPadding}
-                                                        isDisabled={isDisabled}
-                                                    >
-                                                        <TableFooterCellInner
-                                                            align={column.align || Alignment.LEFT}
-                                                            isSorted={column.isSorted}
-                                                        >
-                                                            <TableFooterCellContent>
-                                                                {column.aggregate
-                                                                    ? column.render('Aggregated')
-                                                                    : column.render('Footer')}
-                                                            </TableFooterCellContent>
-                                                        </TableFooterCellInner>
-                                                    </TableFooterCell>
-                                                )
-                                        )}
-                                </TableFooterRow>
-                            ))}
-                        </TableFooter>
-                    )}
-
-                    {footer && (
-                        <TableFooterComponent
-                            elevation={elevation}
-                            isClickable={Boolean(onClickFooter)}
-                            onClick={
-                                onClickFooter
-                                    ? (event: SyntheticEvent): void => {
-                                          onClickFooter(event);
-                                      }
-                                    : undefined
-                            }
-                        >
-                            {footer}
-                        </TableFooterComponent>
-                    )}
-                </StyledTable>
-            </TableWrapper>
-            {paginator && <PaginatorWrapper>{paginator}</PaginatorWrapper>}
+                                    {footer}
+                                </TableFooterComponent>
+                            )}
+                        </StyledTable>
+                    </TableWrapper>
+                    {paginator && <PaginatorWrapper>{paginator}</PaginatorWrapper>}
+                </>
+            )}
         </>
     );
 };


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-991

**Description of the pull request**:
- added props noResultsMessage, choose this name because we already use it in DropdownSelect
- when the instance doesn't have data AND props noResultsMessage is given show CardNoResults instead of table and pagination.
- caption is being rendered anyway
-  had to make IconType optional in CardNoResults
- added to the story of CardNoResults option without icon
- added to the story of Table the option to make it empty, you can change the result message in the addons part or completely remove it to get table headers without data.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
