### PR TITLE
CW-949 styling the footer according to design in CW-949

### DIFF
--- a/src/app/components/organisms/Table/Table.sc.ts
+++ b/src/app/components/organisms/Table/Table.sc.ts
@@ -271,7 +271,13 @@ interface TableFooterComponentProps extends ClickableProps {
 
 export const TableFooterComponent = styled.caption<TableFooterComponentProps>`
     ${({ elevation }): FlattenSimpleInterpolation => getElevation(elevation)}
+    border-top: 4px solid ${({ theme }): string => theme.shades.six};
+    border-left: 8px solid ${({ theme }): string => theme.shades.six};
+    background-color: ${({ theme }): string => theme.table.footer.backgroundColor};
+    padding: ${({ theme }): string => theme.spacing(1.5)};
+    min-height: ${({ theme }): string => theme.spacing(6)}; /* Maintain same height as tablecell */
     caption-side: bottom;
+    text-align: left;
 
     ${({ isClickable }): SimpleInterpolation =>
         isClickable &&

--- a/src/app/components/organisms/Table/Table.stories.tsx
+++ b/src/app/components/organisms/Table/Table.stories.tsx
@@ -109,11 +109,10 @@ export const Configurable: FunctionComponent = () => {
                         isFooterVisible && (
                             <div
                                 style={{
-                                    backgroundColor: 'yellow',
-                                    height: '100px',
+                                    height: '50px',
                                 }}
                             >
-                                {`Column count - 2: ${instance.columns.length - 2}`}
+                                {'Footer text or some component, anything can be placed here'}
                             </div>
                         )
                     }


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-949

**Description of the pull request**:
fot the design of panel passes we are going to use the footer for the first time. 
It is handy to have our design of the footer the same as the footer that is created with the aggregate cells.
added backgroud color, padding and border to the footer to match. 
Inside the footer we can place anything. the Table component still receive a ReactNode and just place it. I only styled the wrapper. 

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
