### PR TITLE
CW-991 noResults props that is ReactNode or string

### DIFF
--- a/src/app/components/organisms/Table/Table.sc.ts
+++ b/src/app/components/organisms/Table/Table.sc.ts
@@ -324,3 +324,23 @@ export const FooterWrapper = styled.div<FooterWrapperProps>`
 export const PaginatorWrapper = styled.div`
     padding: ${({ theme }): string => theme.spacing(1.5, 0, 0)};
 `;
+
+interface StyledCardNoResultsProps {
+    elevation: Elevation;
+}
+
+export const StyledCardNoResults = styled.div<StyledCardNoResultsProps>`
+    ${setBoxSizing()}
+    ${({ elevation }): FlattenSimpleInterpolation => getElevation(elevation)}
+    ${({ theme }): string => theme.textStyling(theme.availableTextStyles().h1)}
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    background-color: ${({ theme }): string => theme.card.backgroundColor};
+    padding: ${({ theme }): string => theme.spacing(3)};
+    color: ${({ theme }): string => theme.colorTextBody.secondary};
+`;
+
+StyledCardNoResults.defaultProps = {
+    theme: themeBasic,
+};

--- a/src/app/components/organisms/Table/Table.stories.tsx
+++ b/src/app/components/organisms/Table/Table.stories.tsx
@@ -1,19 +1,20 @@
-import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { array, boolean, number, select, text } from '@storybook/addon-knobs';
 import {
     createLocalizedPagingTexts,
     createLocalizedTableTexts,
     getTableFooter,
     getTableRow,
 } from './mockup/tableFunctions';
+import { Elevation, IconType } from '../../../types';
 import React, { FunctionComponent, useMemo, useState } from 'react';
 import { tableColumns, tableColumnsWithGroupHeader } from './mockup/tableColumns';
 import { tableData, TableData } from './mockup/tableData';
+import CardNoResults from '../../molecules/CardNoResults/CardNoResults';
 import { createTable } from '../../../utils/functions/createTable';
-import { Elevation } from '../../../types';
 import notes from './notes.md';
 import Paginator from './Paginator/Paginator';
 import SelectionControl from '../../molecules/SelectionControl/SelectionControl';
-import Table from './Table';
+import { Table } from './Table';
 
 export default {
     parameters: {
@@ -120,7 +121,7 @@ export const Configurable: FunctionComponent = () => {
                     hasUnsortedStateIcon={boolean('Has unsorted state icon', true)}
                     instance={instance}
                     isFullWidth={boolean('Is full width', true)}
-                    noResultsMessage={text('No result message', 'No results found')}
+                    noResults={text('No result message', 'No results found')}
                     onClickFooter={isFooterVisible ? getTableFooter : undefined}
                     onClickRow={getTableRow}
                     paginator={
@@ -135,5 +136,55 @@ export const Configurable: FunctionComponent = () => {
                 <div>{'Loading...'}</div>
             )}
         </>
+    );
+};
+
+export const ConfigurableEmptyTableMessage: FunctionComponent = () => {
+    const columns = useMemo(() => tableColumns(), []);
+    const data = useMemo(() => [] as TableData[], []);
+    const localizedTexts = createLocalizedTableTexts('nl');
+
+    const instance = createTable<TableData>(columns, data);
+
+    return (
+        <Table<TableData>
+            caption={text('Table caption', 'Table caption')}
+            elevation={select('Elevation', Elevation, Elevation.LEVEL_1)}
+            instance={instance}
+            isFullWidth={boolean('Is full width', true)}
+            noResults={text('No result message', 'No results found')}
+            onClickRow={getTableRow}
+            paginator={<Paginator<TableData> instance={instance} texts={createLocalizedPagingTexts('nl')} />}
+            texts={{ sortByTooltip: localizedTexts.sortByTooltip }}
+        />
+    );
+};
+
+export const ConfigurableEmptyTableCard: FunctionComponent = () => {
+    const columns = useMemo(() => tableColumns(), []);
+    const data = useMemo(() => [] as TableData[], []);
+    const localizedTexts = createLocalizedTableTexts('nl');
+
+    const instance = createTable<TableData>(columns, data);
+
+    return (
+        <Table<TableData>
+            caption={text('Table caption', 'Table caption')}
+            elevation={select('Elevation', Elevation, Elevation.LEVEL_1)}
+            instance={instance}
+            isFullWidth={boolean('Is full width', true)}
+            noResults={
+                <CardNoResults
+                    elevation={select('Elevation', Elevation, Elevation.LEVEL_1)}
+                    header={text('Header', 'No results found')}
+                    iconType={select('Type', IconType, IconType.SEARCH)}
+                    items={array('Items', ['Option A', 'Option B', 'Option C'])}
+                    title={text('Title', 'What can you do?')}
+                />
+            }
+            onClickRow={getTableRow}
+            paginator={<Paginator<TableData> instance={instance} texts={createLocalizedPagingTexts('nl')} />}
+            texts={{ sortByTooltip: localizedTexts.sortByTooltip }}
+        />
     );
 };

--- a/src/app/components/organisms/Table/Table.tsx
+++ b/src/app/components/organisms/Table/Table.tsx
@@ -6,6 +6,7 @@ import { Alignment, Elevation, IconType } from '../../../types';
 import {
     FooterWrapper,
     PaginatorWrapper,
+    StyledCardNoResults,
     StyledTable,
     TableBody,
     TableCaption,
@@ -27,8 +28,6 @@ import {
 import { getColumnWidthByPercentage, renderSortIcon } from './utils/tableFunctions';
 import React, { ReactNode, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Row, TableInstance } from 'react-table';
-import { CardNoResults } from '../../molecules/CardNoResults/CardNoResults';
-import { isEmpty } from '../../../utils/functions/validateFunctions';
 
 export interface TableTexts {
     sortByTooltip?: ReactNode;
@@ -45,7 +44,7 @@ export interface TableProps<T extends object> {
     instance: TableInstance<T>;
     isDisabled?: boolean;
     isFullWidth?: boolean;
-    noResultsMessage?: string;
+    noResults?: ReactNode | string;
     onClickFooter?: (event: SyntheticEvent) => void;
     onClickRow?: (event: SyntheticEvent, row: Row<T>) => void;
     paginator?: ReactNode;
@@ -65,7 +64,7 @@ export const Table = <T extends object>({
     instance,
     isDisabled = false,
     isFullWidth = true,
-    noResultsMessage,
+    noResults,
     onClickFooter,
     onClickRow,
     paginator,
@@ -113,11 +112,18 @@ export const Table = <T extends object>({
         }
     }, [availableTableWidth, tableWrapperRef, fixedColumnWidthsTotal]);
 
+    // eslint-disable-next-line no-console
+    console.log(noResults, typeof noResults);
+
     return (
         <>
             {caption && <TableCaption>{caption}</TableCaption>}
-            {!hasResults && !isEmpty(noResultsMessage) ? (
-                <CardNoResults header={noResultsMessage} title={''} />
+            {!hasResults && noResults ? (
+                typeof noResults === 'string' ? (
+                    <StyledCardNoResults elevation={elevation}>{noResults}</StyledCardNoResults>
+                ) : (
+                    noResults
+                )
             ) : (
                 <TableWrapper ref={tableWrapperRef}>
                     <StyledTable className={className} isFullWidth={isFullWidth} {...getTableProps()}>


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-991

**Description of the pull request**:
- changed the props noResultMessage to noResult
- this props is optional and can get either a ReactNode or a string.
- an example for a table that will use the ReactNode props:
https://projects.invisionapp.com/d/main#/console/20400204/435729706/preview
- other tables like in member details will have a string props. the component Table will take care of the styling with a styled-component so no changes on CardNoResults because done.



<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
