### PR TITLE
CW-1054 onClickRow to expect only the table State instead of the whole instance

### DIFF
--- a/src/app/components/organisms/Table/Table.tsx
+++ b/src/app/components/organisms/Table/Table.tsx
@@ -27,7 +27,7 @@ import {
 } from './Table.sc';
 import { getColumnWidthByPercentage, renderSortIcon } from './utils/tableFunctions';
 import React, { ReactNode, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { Row, TableInstance } from 'react-table';
+import { Row, TableInstance, TableState } from 'react-table';
 
 export interface TableTexts {
     sortByTooltip?: ReactNode;
@@ -46,7 +46,7 @@ export interface TableProps<T extends object> {
     isFullWidth?: boolean;
     noResults?: ReactNode | string;
     onClickFooter?: (event: SyntheticEvent) => void;
-    onClickRow?: (event: SyntheticEvent, row: Row<T>, instance: TableInstance<T>) => void;
+    onClickRow?: (event: SyntheticEvent, row: Row<T>, tableState: TableState<T>) => void;
     paginator?: ReactNode;
     texts?: TableTexts;
 }
@@ -173,7 +173,7 @@ export const Table = <T extends object>({
                                         onClick={
                                             onClickRow
                                                 ? (event: SyntheticEvent): void => {
-                                                      onClickRow(event, row, instance);
+                                                      onClickRow(event, row, instance.state);
                                                   }
                                                 : undefined
                                         }

--- a/src/app/components/organisms/Table/mockup/tableFunctions.tsx
+++ b/src/app/components/organisms/Table/mockup/tableFunctions.tsx
@@ -2,7 +2,7 @@ import { ButtonSize, ButtonVariant, IconType } from '../../../../types';
 import React, { SyntheticEvent } from 'react';
 import { action } from '@storybook/addon-actions';
 import Button from '../../../molecules/Button/Button';
-import { TableInstance } from 'react-table';
+import { TableState } from 'react-table';
 
 export const createLocalizedTableTexts = (
     language = 'nl'
@@ -46,17 +46,13 @@ export const getTableCell = (cell: unknown, row: unknown, event: SyntheticEvent)
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const getTableRow = <T extends object>(
-    event: SyntheticEvent,
-    row: unknown,
-    instance: TableInstance<T>
-): void => {
+export const getTableRow = <T extends object>(event: SyntheticEvent, row: unknown, tableState: TableState<T>): void => {
     // eslint-disable-next-line no-console
     console.log('Clicked row:', row);
     // eslint-disable-next-line no-console
     console.log('Event:', event);
     // eslint-disable-next-line no-console
-    console.log('Instance:', instance);
+    console.log('Instance:', tableState);
 };
 
 export const getTableFooter = (event: SyntheticEvent): void => {

--- a/src/app/components/organisms/Table/mockup/tableFunctions.tsx
+++ b/src/app/components/organisms/Table/mockup/tableFunctions.tsx
@@ -52,7 +52,7 @@ export const getTableRow = <T extends object>(event: SyntheticEvent, row: unknow
     // eslint-disable-next-line no-console
     console.log('Event:', event);
     // eslint-disable-next-line no-console
-    console.log('Instance:', tableState);
+    console.log('Instance state:', tableState);
 };
 
 export const getTableFooter = (event: SyntheticEvent): void => {


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

https://jira.sportlink.nl/browse/CW-1054

**Description of the pull request**:
change the expected parameters of onClickRow to expect the table state instead of the whole instance because we aren't going to do anything with the rest of the properties.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
