### PR TITLE
CW-1072 add validation for the rest of the editable data types

### DIFF
--- a/src/app/__tests__/utils/functions/informationDataFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/informationDataFunctions.test.ts
@@ -1,0 +1,62 @@
+import {
+    DatePickerDataProps,
+    EditableDropdownDataProps,
+} from '../../../components/organisms/EditableInformation/types';
+import { EditableDataComponent } from '../../../types';
+import { fruits } from '../../../components/organisms/EditableInformation/mockup/editableInformationData';
+import { isValidEditableInput } from '../../../components/organisms/EditableInformation/utils/informationDataFunctions';
+import moment from 'moment';
+
+describe('test function isValidEditableInput', () => {
+    test('test isRequired DatePicker', () => {
+        const data = [
+            {
+                component: EditableDataComponent.DATEPICKER,
+                isEditable: true,
+                isRequired: true,
+                label: 'Date',
+                name: 'Date',
+                value: null,
+            } as DatePickerDataProps,
+        ];
+
+        expect(
+            isValidEditableInput(data, {
+                Date: moment(),
+            })
+        ).toBe(true);
+
+        expect(
+            isValidEditableInput(data, {
+                Date: null,
+            })
+        ).toBe(false);
+    });
+
+    test('test isRequired Dropdown', () => {
+        const data = [
+            {
+                component: EditableDataComponent.DROPDOWN,
+                isEditable: true,
+                isRequired: true,
+                label: 'Dropdown',
+                name: 'Dropdown',
+                nameTextValue: ' DropdownId',
+                options: fruits,
+                value: '',
+            } as EditableDropdownDataProps,
+        ];
+
+        expect(
+            isValidEditableInput(data, {
+                Dropdown: '',
+            })
+        ).toBe(false);
+
+        expect(
+            isValidEditableInput(data, {
+                Dropdown: '2',
+            })
+        ).toBe(true);
+    });
+});

--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.sc.ts
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.sc.ts
@@ -5,6 +5,7 @@ import { themeBasic } from '../../../../styles/theming/themes/basic';
 export const StyledWrapper = styled.div``;
 
 interface StyledSingleDatePickerProps {
+    hasError: boolean;
     isFocused: boolean;
     isTopDatepicker: boolean;
     variant: SingleDatePickerVariant;
@@ -36,7 +37,7 @@ export const StyledSingleDatePicker = styled.div<StyledSingleDatePickerProps>`
                 height: ${`calc(${theme.spacing(3)} + 1px)`};
             `}
 
-        ${({ isFocused, theme, variant }): SimpleInterpolation =>
+        ${({ hasError, isFocused, theme, variant }): SimpleInterpolation =>
             variant === SingleDatePickerVariant.COMPACT &&
             css`
                 overflow: visible;
@@ -49,6 +50,11 @@ export const StyledSingleDatePicker = styled.div<StyledSingleDatePickerProps>`
                     ${isFocused &&
                     css`
                         background-color: ${theme.colorSecondary};
+                    `}
+
+                    ${hasError &&
+                    css`
+                        background-color: ${theme.colorInvalid};
                     `}
                 }
             `}

--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -26,6 +26,7 @@ export interface SingleDatePickerProps {
     daySize?: number;
     displayFormat?: string;
     footerText?: DialogFooterProps['text'];
+    hasError?: boolean;
     hasYearSelector?: boolean;
     id: string;
     isDayBlocked?: (day: Moment) => boolean;
@@ -58,6 +59,7 @@ export const SingleDatePicker: FunctionComponent<SingleDatePickerProps> = ({
     daySize = 40,
     displayFormat = 'ddd D MMM Y',
     footerText,
+    hasError = false,
     hasYearSelector = false,
     id,
     isDayBlocked,
@@ -172,7 +174,12 @@ export const SingleDatePicker: FunctionComponent<SingleDatePickerProps> = ({
                     setIsHovered(false);
                 }}
             >
-                <StyledSingleDatePicker isFocused={isFocused} isTopDatepicker={isTopDatepicker} variant={variant}>
+                <StyledSingleDatePicker
+                    hasError={hasError}
+                    isFocused={isFocused}
+                    isTopDatepicker={isTopDatepicker}
+                    variant={variant}
+                >
                     {label && (
                         <FormElementLabel
                             isActive

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -10,6 +10,7 @@ import DropdownSelect from '../../DropdownSelect/DropdownSelect';
 import { InformationTableProps } from '../../InformationTable';
 import Input from '../../../molecules/Input/Input';
 import InputCurrency from '../../InputCurrency/InputCurrency';
+import { isEmpty } from '../../../../../lib';
 import React from 'react';
 import ScorePicker from '../../../molecules/ScorePicker/ScorePicker';
 import { SelectionControl } from '../../../molecules/SelectionControl';
@@ -59,6 +60,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
             }
 
             const { name } = dataInstance;
+            const hasError = isRequired && isEmpty(values[name]);
 
             if (dataInstance.component === EditableDataComponent.CHECKBOX) {
                 return {
@@ -66,7 +68,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     value: (
                         <SelectionControl
                             errorMessage={dataInstance.errorMessage}
-                            hasError={isRequired && Boolean(name) && !values[name]}
+                            hasError={hasError}
                             hasVerticalCorrection
                             isChecked={values[name] as boolean}
                             isDisabled={isDisabled}
@@ -88,6 +90,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                         <SingleDatePicker
                             date={values[name] as moment.Moment | null}
                             displayFormat={dataInstance.dateFormat || dateFormat}
+                            hasError={hasError}
                             id={name}
                             isDisabled={isDisabled}
                             isFocused={datePickerFocuses[name]}
@@ -112,7 +115,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     textValue: dataInstance.textValue,
                     value: (
                         <Dropdown
-                            hasError={isRequired && Boolean(name) && !values[name]}
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             name={name}
                             onChange={({ currentTarget }): void => {
@@ -142,6 +145,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             buttonCancelText={dataInstance.buttonCancelText}
                             buttonConfirmText={dataInstance.buttonConfirmText}
                             deselectAllLabel={dataInstance.deselectAllLabel}
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             maxHeight={dataInstance.maxHeight}
                             minHeight={dataInstance.minHeight}
@@ -162,7 +166,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                         <DropdownSelect
                             defaultValue={dataInstance.defaultValue}
                             footerText={dataInstance.footerText}
-                            hasError={isRequired && Boolean(name) && !values[name]}
+                            hasError={hasError}
                             iconType={dataInstance.iconType}
                             isDisabled={isDisabled}
                             name={dataInstance.name}
@@ -186,7 +190,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     label,
                     value: (
                         <Input
-                            hasError={isRequired && Boolean(name) && !values[name]}
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             label={dataInstance.placeholder}
                             maxLength={dataInstance.maxLength}
@@ -222,6 +226,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     label,
                     value: (
                         <InputCurrency
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             isRequired={isRequired}
                             locale={dataInstance.locale}
@@ -258,7 +263,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     label,
                     value: (
                         <Input
-                            hasError={isRequired && Boolean(name) && values[name] === undefined}
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             isRequired={isRequired}
                             label={dataInstance.placeholder}
@@ -311,7 +316,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     label,
                     value: (
                         <Input
-                            hasError={isRequired && Boolean(name) && !values[name]}
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             isRequired={isRequired}
                             isTextarea
@@ -347,7 +352,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                     label,
                     value: (
                         <Input
-                            hasError={isRequired && Boolean(name) && !values[name]}
+                            hasError={hasError}
                             isDisabled={isDisabled}
                             isTextarea
                             label={dataInstance.placeholder}
@@ -376,7 +381,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                 label,
                 value: (
                     <Input
-                        hasError={isRequired && Boolean(name) && !values[name]}
+                        hasError={hasError}
                         isDisabled={isDisabled}
                         isRequired={isRequired}
                         name={name}

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -10,7 +10,7 @@ import DropdownSelect from '../../DropdownSelect/DropdownSelect';
 import { InformationTableProps } from '../../InformationTable';
 import Input from '../../../molecules/Input/Input';
 import InputCurrency from '../../InputCurrency/InputCurrency';
-import { isEmpty } from '../../../../../lib';
+import { isEmpty } from '../../../../utils/functions/validateFunctions';
 import React from 'react';
 import ScorePicker from '../../../molecules/ScorePicker/ScorePicker';
 import { SelectionControl } from '../../../molecules/SelectionControl';

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -94,11 +94,12 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
 
     result.push({
         component: EditableDataComponent.DATEPICKER,
+        isDisabled: true,
         isEditable: true,
-        isRequired: true,
+        isVisibleOnlyOnEdit: true,
         label: 'Date',
         name: 'Date',
-        value: null,
+        value: moment(),
     } as DatePickerDataProps);
 
     result.push({
@@ -131,6 +132,33 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         onKeyDown: onKeyDownCallback,
         value: 0,
     } as EditableInputNumberDataProps);
+
+    result.push({
+        component: EditableDataComponent.INPUTNUMBER,
+        isDisabled: false,
+        isEditable: true,
+        isRequired: true,
+        label: 'BadNumber',
+        min: 0,
+        name: 'BadNumber',
+        onBlur: onBlurCallback,
+        onFocus: onFocusCallback,
+        onKeyDown: onKeyDownCallback,
+        value: -1,
+    } as EditableInputNumberDataProps);
+
+    result.push({
+        component: EditableDataComponent.INPUT,
+        isDisabled: false,
+        isEditable: true,
+        isRequired: true,
+        label: 'Input (null value)',
+        name: 'InputNull',
+        onBlur: onBlurCallback,
+        onFocus: onFocusCallback,
+        onKeyDown: onKeyDownCallback,
+        value: null,
+    } as EditableInputDataProps);
 
     result.push({
         component: EditableDataComponent.INPUT,

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -47,7 +47,7 @@ export const updateValuesOfData = <T extends DropdownSelectOption, U extends Dro
     return newData as EditableInformationData<T, U>;
 };
 
-const fruits: Fruit[] = [
+export const fruits: Fruit[] = [
     {
         adornment: <IconCustomizable iconSize={IconCustomizableSize.SIZE24} iconType={IconType.CLUBPLACEHOLDER10} />,
         isSelected: true,
@@ -94,12 +94,11 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
 
     result.push({
         component: EditableDataComponent.DATEPICKER,
-        isDisabled: true,
         isEditable: true,
-        isVisibleOnlyOnEdit: true,
+        isRequired: true,
         label: 'Date',
         name: 'Date',
-        value: moment(),
+        value: null,
     } as DatePickerDataProps);
 
     result.push({
@@ -132,33 +131,6 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         onKeyDown: onKeyDownCallback,
         value: 0,
     } as EditableInputNumberDataProps);
-
-    result.push({
-        component: EditableDataComponent.INPUTNUMBER,
-        isDisabled: false,
-        isEditable: true,
-        isRequired: true,
-        label: 'BadNumber',
-        min: 0,
-        name: 'BadNumber',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
-        value: -1,
-    } as EditableInputNumberDataProps);
-
-    result.push({
-        component: EditableDataComponent.INPUT,
-        isDisabled: false,
-        isEditable: true,
-        isRequired: true,
-        label: 'Input (null value)',
-        name: 'InputNull',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
-        value: null,
-    } as EditableInputDataProps);
 
     result.push({
         component: EditableDataComponent.INPUT,

--- a/src/app/utils/functions/validateFunctions.ts
+++ b/src/app/utils/functions/validateFunctions.ts
@@ -4,9 +4,13 @@ import { Locale } from '../../types';
 import { toMoneyValue } from './financialFunctions';
 import toNumber from './toNumber';
 
-export const isEmpty = (value: string | unknown | undefined | null): boolean => {
+export const isEmpty = (value: string | unknown | undefined | null | Array<unknown>): boolean => {
     if (value === null || typeof value === 'undefined') {
         return true;
+    }
+
+    if (Array.isArray(value)) {
+        return value.length <= 0;
     }
 
     if (typeof value === 'string') {


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1072

**Description of the pull request**:
- add validation also for Editable data types DROPDOWN, DROPDOWNSELECT, DROPDOWNMULTISELECT and DATEPICKER
- validation is to check that if this field is required the value is not empty. 
- added to isEmpty check for arrays
- changed the function isValidEditableInput to immediately return the value that comes out of data.every. this function stops at the moment that one of the items returns false. 
- added to SingleDatePicker hasErrors to show a red line in variant compact (same as input) 
- added a test (not complete yet) for testing validating dropdowns and dates (to run :` npm run test informationDataFunctions` )

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
