### PR TITLE
CW-1057 isValidDate to not fall if the string is in a format that doesnt pass…

### DIFF
--- a/src/app/__tests__/utils/functions/dateFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/dateFunctions.test.ts
@@ -1,0 +1,10 @@
+import { currentDate, isValidDate } from '../../../utils/functions/dateFunctions';
+
+describe('test date functions', () => {
+    test('test isValidDate', () => {
+        expect(isValidDate(currentDate())).toBe(true);
+        expect(isValidDate('21')).toBe(false);
+        expect(isValidDate('2021-03-26T13:21:50.000Z')).toBe(true);
+        expect(isValidDate('Fri Mar 26 2021 14:21:50 GMT+0100 (Central European Standard Time)')).toBe(true);
+    });
+});

--- a/src/app/utils/functions/dateFunctions.ts
+++ b/src/app/utils/functions/dateFunctions.ts
@@ -12,20 +12,13 @@ export const isValidStringDate = (inputText: string): boolean => {
     return dateWithTimezoneRegExp.test(inputText) || dateFormatRegExp.test(inputText);
 };
 
-export const isValidDate = (value: string | Date | Moment): boolean => {
-    // If the value is a string, then some checks need to be done, otherwise moment will throw warnings in the console
-    if (typeof value === 'string') {
-        return isValidStringDate(value);
-    }
-
-    return (
-        moment.isMoment(value) ||
-        moment.isDate(value) ||
-        ((moment.parseZone(value).inspect().includes('moment.parseZone') ||
-            moment.parseZone(value).inspect().includes('moment.utc')) &&
-            !moment.parseZone(value).inspect().includes('moment.invalid'))
-    );
-};
+export const isValidDate = (value: string | Date | Moment): boolean =>
+    (typeof value === 'string' && isValidStringDate(value)) ||
+    moment.isMoment(value) ||
+    moment.isDate(value) ||
+    ((moment.parseZone(value).inspect().includes('moment.parseZone') ||
+        moment.parseZone(value).inspect().includes('moment.utc')) &&
+        !moment.parseZone(value).inspect().includes('moment.invalid'));
 
 export const isValidClockTime = (value: string): boolean => {
     const timeRegExp = /^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$/;


### PR DESCRIPTION
… regExp tests

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1057

**Description of the pull request**:
value to isValidDate can be a string that doesn't pass the regExp tests
the date string that comes from a token information has the form "Fri Mar 26 2021 14:21:50 GMT+0100 (Central European Standard Time)", it will fall if only tests on regExp, but it does pass the last condition in isValidDate: `((moment.parseZone(value).inspect().includes('moment.parseZone') ||
        moment.parseZone(value).inspect().includes('moment.utc')) &&
        !moment.parseZone(value).inspect().includes('moment.invalid'));`

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
