### PR TITLE
CW-1061 resolve warning datePicker negative verticalSpacing

### DIFF
--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.sc.ts
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.sc.ts
@@ -69,10 +69,10 @@ export const StyledSingleDatePicker = styled.div<StyledSingleDatePickerProps>`
     }
 
     .SingleDatePicker_picker {
-        ${({ isTopDatepicker }): SimpleInterpolation =>
+        ${({ isTopDatepicker, variant }): SimpleInterpolation =>
             isTopDatepicker &&
             css`
-                margin-bottom: 5px;
+                margin-bottom: ${variant === SingleDatePickerVariant.COMPACT ? '16px' : '8px'};
             `}
     }
 `;

--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -234,7 +234,8 @@ export const SingleDatePicker: FunctionComponent<SingleDatePickerProps> = ({
                                 yearCountFuture={yearCountFuture}
                             />
                         )}
-                        verticalSpacing={spacingValue * (variant === SingleDatePickerVariant.OUTLINE ? 6 : 3.25) - 40}
+                        small={variant === SingleDatePickerVariant.COMPACT}
+                        verticalSpacing={variant === SingleDatePickerVariant.OUTLINE ? spacingValue : 0}
                     />
                 </StyledSingleDatePicker>
             </Wrapper>


### PR DESCRIPTION
…tioning calendar

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1061

**Description of the pull request**:
- use small for correct calculation of "top" value of .SingleDatePicker_picker element
- fix bottom margin when datepicker opens up. also 5px is not something we use, changed it to 8px. for compact it needs to be 16px otherwise the date picker opens aboven the input label 
- 
tested it also in editableInformation stories.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
