### PR TITLE
fix validation input number

### DIFF
--- a/src/app/__tests__/utils/functions/informationDataFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/informationDataFunctions.test.ts
@@ -1,6 +1,7 @@
 import {
     DatePickerDataProps,
     EditableDropdownDataProps,
+    EditableInputNumberDataProps,
 } from '../../../components/organisms/EditableInformation/types';
 import { DEFAULT_LOCALE } from '../../../../global/constants';
 import { EditableDataComponent } from '../../../types';
@@ -75,5 +76,62 @@ describe('test function isValidEditableInput', () => {
                 DEFAULT_LOCALE
             )
         ).toBe(true);
+    });
+
+    test('test InputNumber null value', () => {
+        const data = [
+            {
+                component: EditableDataComponent.INPUTNUMBER,
+                isDisabled: false,
+                isEditable: true,
+                label: 'BadNumber',
+                min: 0,
+                name: 'BadNumber',
+                value: null,
+            } as EditableInputNumberDataProps,
+        ];
+
+        expect(
+            isValidEditableInput(
+                data,
+                {
+                    BadNumber: -1,
+                },
+                DEFAULT_LOCALE
+            )
+        ).toBe(false);
+
+        expect(
+            isValidEditableInput(
+                data,
+                {
+                    BadNumber: null,
+                },
+                DEFAULT_LOCALE
+            )
+        ).toBe(true);
+
+        expect(
+            isValidEditableInput(
+                data,
+                {
+                    BadNumber: '',
+                },
+                DEFAULT_LOCALE
+            )
+        ).toBe(true);
+
+        expect(
+            isValidEditableInput(
+                data.map((item) => ({
+                    ...item,
+                    isRequired: true,
+                })),
+                {
+                    BadNumber: null,
+                },
+                DEFAULT_LOCALE
+            )
+        ).toBe(false);
     });
 });

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -100,7 +100,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     return isValidInputEmail(valueToValidate, isRequired);
 
                 case InputType.NUMBER:
-                    return isValidInputNumber(toNumber(valueToValidate), locale, isRequired, min, max);
+                    return isValidInputNumber(valueToValidate, locale, isRequired, min, max);
 
                 case InputType.TELEPHONE:
                     return isValidInputTelephone(valueToValidate, isRequired, locale);

--- a/src/app/components/organisms/EditableInformation/types.ts
+++ b/src/app/components/organisms/EditableInformation/types.ts
@@ -95,7 +95,7 @@ export interface EditableDropdownMultiSelectDataProps<T extends DropdownMultiSel
 
 export interface InputNumberDataProps extends BaseDataProps {
     component: EditableDataComponent.INPUTNUMBER;
-    value: number;
+    value: number | null;
 }
 
 export interface EditableInputNumberDataProps extends InputNumberDataProps {


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1112

**Description of the pull request**:
- isValidEditableInput not validating correctly when isEmpty(Value) and also not required input
- that was because of converting the value to a number first. the isValidEditableInput can handle null, undefined and string, no need to convert before the validation. convertion is happening inside the function when testing against min and max
-

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
