### PR TITLE
CW-1108 refactor is valid date and to date

### DIFF
--- a/src/app/__tests__/utils/functions/dateFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/dateFunctions.test.ts
@@ -1,23 +1,18 @@
-import { currentDate, isFutureDate, isValidDate, toMoment } from '../../../utils/functions/dateFunctions';
-import moment, { Moment } from 'moment';
+import { currentDate, isFutureDate, isValidDate, toDate, toMoment } from '../../../utils/functions/dateFunctions';
 import { Locale } from '../../../types';
+import moment from 'moment';
 
 describe('test date functions', () => {
-    test('test toMoment', () => {
-        expect(toMoment('2003-12-21')).toMatchObject({} as Moment);
-        expect(toMoment('21-12-2003')).toMatchObject({} as Moment);
-        expect(toMoment('21-12-2003', Locale.NL, 'DD-MM-YYYY')).toMatchObject({} as Moment);
-        expect(toMoment('12-21-2003', Locale.NL, 'MM-DD-YYYY')).toMatchObject({} as Moment);
-        expect(toMoment('12-21-2003', Locale.EN)).toMatchObject({} as Moment);
-    });
-
     test('test isValidDate', () => {
         expect(isValidDate(currentDate())).toBe(true);
-        expect(isValidDate('21-12-2003')).toBe(true);
-        expect(isValidDate('12-21-2003')).toBe(true);
+        expect(isValidDate('2021-02-29')).toBe(false); // this date doesn't exist in the calendar
+        expect(isValidDate('2021-09-31')).toBe(false); // this date doesn't exist in the calendar
+        expect(isValidDate('2021-09-30')).toBe(true);
         expect(isValidDate('21')).toBe(false);
         expect(isValidDate('2021-03-26T13:21:50.000Z')).toBe(true);
         expect(isValidDate('Fri Mar 26 2021 14:21:50 GMT+0100 (Central European Standard Time)')).toBe(true);
+        expect(isValidDate('commissie 1')).toBe(false);
+        expect(isValidDate('30-09-2021')).toBe(true);
     });
 
     test('test isFutureDate', () => {
@@ -25,9 +20,29 @@ describe('test date functions', () => {
         expect(isFutureDate(moment())).toBe(false);
         expect(isFutureDate(moment(), true)).toBe(true);
         expect(isFutureDate(toMoment('2021-04-08'), true)).toBe(false);
-        expect(isFutureDate(moment(), true)).toBe(true);
-        expect(isFutureDate(moment(), false)).toBe(false);
         expect(isFutureDate(moment().add(1, 'day'), true)).toBe(true);
         expect(isFutureDate(moment().add(1, 'day'))).toBe(true);
+    });
+
+    test('test toMoment', () => {
+        expect(toMoment('')).toBe(null);
+        expect(toMoment('2021-09-30')).toStrictEqual(moment('2021-09-30').locale(Locale.NL));
+        expect(toMoment('2021-09-31')).toBe(null); // this date doesn't exist in the calendar
+    });
+
+    test('test toDate', () => {
+        expect(toDate('')).toBe(null);
+        expect(toDate('2021-09-30')).toStrictEqual(moment('2021-09-30').locale('nl').toDate());
+        expect(toDate('2021-09-31')).toBe(null); // this date doesn't exist in the calendar
+        expect(toDate('2021-09-31')).toBe(null); // this date doesn't exist in the calendar
+
+        // with different format than the default format
+        expect(toDate('21-02-2021', Locale.NL, 'DD-MM-YYYY')).toStrictEqual(
+            moment('21-02-2021', 'DD-MM-YYYY').locale(Locale.NL).toDate()
+        );
+
+        expect(toDate('02-21-2021', Locale.NL, 'MM-DD-YYYY')).toStrictEqual(
+            moment('02-21-2021', 'MM-DD-YYYY').locale(Locale.NL).toDate()
+        );
     });
 });

--- a/src/app/__tests__/utils/functions/dateFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/dateFunctions.test.ts
@@ -13,6 +13,8 @@ describe('test date functions', () => {
         expect(isValidDate('Fri Mar 26 2021 14:21:50 GMT+0100 (Central European Standard Time)')).toBe(true);
         expect(isValidDate('commissie 1')).toBe(false);
         expect(isValidDate('30-09-2021')).toBe(true);
+        expect(isValidDate('30-09-2021', Locale.NL)).toBe(true);
+        expect(isValidDate('09-30-2021', Locale.NL, 'MM-DD-YYYY')).toBe(true);
     });
 
     test('test isFutureDate', () => {

--- a/src/app/__tests__/utils/functions/dateFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/dateFunctions.test.ts
@@ -1,4 +1,5 @@
 import { currentDate, isFutureDate, isValidDate, toDate, toMoment } from '../../../utils/functions/dateFunctions';
+import { DEFAULT_DATE_FORMAT } from '../../../../global/constants';
 import { Locale } from '../../../types';
 import moment from 'moment';
 
@@ -28,8 +29,17 @@ describe('test date functions', () => {
 
     test('test toMoment', () => {
         expect(toMoment('')).toBe(null);
-        expect(toMoment('2021-09-30')).toStrictEqual(moment('2021-09-30').locale(Locale.NL));
+        expect(toMoment('2021-09-30')).toStrictEqual(moment('2021-09-30', DEFAULT_DATE_FORMAT).locale(Locale.NL));
         expect(toMoment('2021-09-31')).toBe(null); // this date doesn't exist in the calendar
+
+        // with different format than the default format
+        expect(toMoment('21-02-2021', Locale.NL, 'DD-MM-YYYY')).toStrictEqual(
+            moment('21-02-2021', 'DD-MM-YYYY').locale(Locale.NL)
+        );
+
+        expect(toMoment('02-21-2021', Locale.NL, 'MM-DD-YYYY')).toStrictEqual(
+            moment('02-21-2021', 'MM-DD-YYYY').locale(Locale.NL)
+        );
     });
 
     test('test toDate', () => {

--- a/src/app/components/organisms/Table/ContentCell/ContentCell.tsx
+++ b/src/app/components/organisms/Table/ContentCell/ContentCell.tsx
@@ -12,7 +12,6 @@ export interface ContentCellProps {
     hasTooltip?: boolean;
     isBold?: boolean;
     isCurrency?: boolean;
-    isDate?: boolean;
     isDisabled?: boolean;
     isImage?: boolean;
     isTime?: boolean;
@@ -30,7 +29,6 @@ export const ContentCell: FunctionComponent<ContentCellProps> = ({
     hasTooltip = false,
     isCurrency = false,
     isBold = false,
-    isDate = false,
     isDisabled = false,
     isImage = false,
     isTime = false,
@@ -61,7 +59,7 @@ export const ContentCell: FunctionComponent<ContentCellProps> = ({
         );
     }
 
-    if ((isTime || isDate) && typeof value === 'string') {
+    if (typeof value === 'string') {
         if (isTime) {
             if (isValidClockTime(value)) {
                 content = formatTime(value);

--- a/src/app/components/organisms/Table/mockup/tableColumns.tsx
+++ b/src/app/components/organisms/Table/mockup/tableColumns.tsx
@@ -89,7 +89,7 @@ export const tableColumns = (): Column<TableData>[] => [
         align: Alignment.RIGHT,
     },
     {
-        Cell: ({ value }): ReactNode => <ContentCell isDate value={value} />,
+        Cell: ({ value }): ReactNode => <ContentCell value={value} />,
         Header: 'Startdate',
         accessor: 'relationStart',
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/utils/functions/dateFunctions.ts
+++ b/src/app/utils/functions/dateFunctions.ts
@@ -83,7 +83,7 @@ export const toMoment = (
     value: string | Date | Moment,
     lang: string = DEFAULT_LOCALE,
     format = DEFAULT_DATE_FORMAT
-): Moment | null => (isValidDate(value, lang, format) ? moment(moment(value).format(format)).locale(lang) : null);
+): Moment | null => (isValidDate(value, lang, format) ? moment(value, format).locale(lang) : null);
 
 export const compareDates = (d1: Moment | Date | string | null, d2: Moment | Date | string | null): boolean => {
     const D1 = toMoment(d1 || '');

--- a/src/app/utils/functions/dateFunctions.ts
+++ b/src/app/utils/functions/dateFunctions.ts
@@ -10,13 +10,21 @@ export const isValidStringDate = (inputText: string): boolean => {
     return dateWithTimezoneRegExp.test(inputText) || dateFormatRegExp.test(inputText);
 };
 
-export const isValidDate = (value: string | Date | Moment): boolean =>
-    (typeof value === 'string' && isValidStringDate(value)) ||
-    moment.isMoment(value) ||
-    moment.isDate(value) ||
-    ((moment.parseZone(value).inspect().includes('moment.parseZone') ||
-        moment.parseZone(value).inspect().includes('moment.utc')) &&
-        !moment.parseZone(value).inspect().includes('moment.invalid'));
+export const isValidDate = (
+    value: string | Date | Moment,
+    lang: string = DEFAULT_LOCALE,
+    format = DEFAULT_DATE_FORMAT
+): boolean => {
+    if (typeof value === 'string' && !isValidStringDate(value)) {
+        return moment.parseZone(value).inspect().includes('moment.parseZone');
+    }
+
+    return (
+        (typeof value === 'string' && moment(value, format).locale(lang).isValid()) ||
+        moment.isMoment(value) ||
+        moment.isDate(value)
+    );
+};
 
 export const isValidClockTime = (value: string): boolean => {
     const timeRegExp = /^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$/;
@@ -63,16 +71,19 @@ export const isFutureDate = (date: Moment | null, includeToday = false): boolean
     ((includeToday && date.isSameOrAfter(moment(), 'day')) || (!includeToday && date.isAfter(moment(), 'day')));
 
 // Can not use Date constructor due to browser differences, hence this function
-export const toDate = (value: string | Date | Moment, lang: string = DEFAULT_LOCALE): Date | null =>
-    isValidDate(value) ? moment(value).locale(lang).toDate() : null;
+export const toDate = (
+    value: string | Date | Moment,
+    lang: string = DEFAULT_LOCALE,
+    format = DEFAULT_DATE_FORMAT
+): Date | null => (isValidDate(value, lang, format) ? moment(value, format).locale(lang).toDate() : null);
 
 export const currentDate = (lang: string = DEFAULT_LOCALE): Date => moment().locale(lang).toDate();
 
 export const toMoment = (
     value: string | Date | Moment,
     lang: string = DEFAULT_LOCALE,
-    format: string = DEFAULT_DATE_FORMAT
-): Moment | null => (isValidDate(value) ? moment(moment(value).format(format)).locale(lang) : null);
+    format = DEFAULT_DATE_FORMAT
+): Moment | null => (isValidDate(value, lang, format) ? moment(moment(value).format(format)).locale(lang) : null);
 
 export const compareDates = (d1: Moment | Date | string | null, d2: Moment | Date | string | null): boolean => {
     const D1 = toMoment(d1 || '');


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1108

**Description of the pull request**:
- add format also to toDate, with defaults
- fix isValidDate - to take into consideration the format and locale. 
if it is not a string that passes the regExp than it could only be the long string with text such as (Central European Standard Time) if it is a string it should also be possible to convert it to a valid moment (so no dates that doens't exisit like 31 sptember) and if it isn't a string then it is either moment or date.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
