### PR TITLE
CW-1095 onchange to expect isDataChanged boolean, 

### DIFF
--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -42,9 +42,9 @@ export interface EditableInformationProps<T extends DropdownOption, U extends Dr
     keepEditMode?: boolean;
     locale?: Locale;
     onCancel?: () => void;
-    onChange?: (data: unknown) => void;
+    onChange?: (data: unknown, isDataChanged: boolean) => void;
     onEdit?: () => void;
-    onSave?: (data: { [key: string]: ValueTypes<T, U> }, isDataChanged?: boolean) => void;
+    onSave?: (data: { [key: string]: ValueTypes<T, U> }, isDataChanged: boolean) => void;
     onValidation?: (isValidData: boolean) => void;
     saveConfirmDialog?: ConfirmDialog;
     status?: Status;
@@ -145,10 +145,10 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
             };
 
             if (onChange) {
-                onChange(newValues);
+                onChange(newValues, !areEqualObjects(newValues, originalValues));
             }
         },
-        [onChange, updatedValues]
+        [onChange, originalValues, updatedValues]
     );
 
     const onDatePickerFocusChangeCallback = useCallback(
@@ -179,10 +179,10 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
             setUpdatedValues(newValues);
 
             if (onChange) {
-                onChange(newValues);
+                onChange(newValues, !areEqualObjects(newValues, originalValues));
             }
         },
-        [updatedValues]
+        [onChange, originalValues, updatedValues]
     );
 
     useEffect(() => {


### PR DESCRIPTION
…olean, it is never underfined

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1095

**Description of the pull request**:
- onChange to expect a boolean back
- als the boolean in onSave always have a value, it is always something that is returned from areEqualObjects so it is never undefined. It is still possible to not do with it anything

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
