### PR TITLE
CW-1095 only switch tab if allowed, tab numer 0 is valid

### DIFF
--- a/src/app/components/organisms/Tabs/Tabs.stories.tsx
+++ b/src/app/components/organisms/Tabs/Tabs.stories.tsx
@@ -22,6 +22,7 @@ export const Configurable: FunctionComponent = () => (
         hasFullWidthTabHeaders={boolean('Has fullwidth tab headers', true)}
         hasPadding={boolean('Has padding', false)}
         initiallyActiveTabIndex={select('Active tab', [1, 2], 1)}
+        isChangeTabAllowed={boolean('Is change Tab allowed', true)}
         isSmall={boolean('Is small', false)}
         onClickTab={getTab}
         tabs={[

--- a/src/app/components/organisms/Tabs/Tabs.tsx
+++ b/src/app/components/organisms/Tabs/Tabs.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, ReactNode, SyntheticEvent, useEffect, useState } from 'react';
 import { StyledTabs, TabHeader, TabHeaders, TabHeaderText, TabPanel } from './Tabs.sc';
+import { isEmpty } from '../../../utils/functions/validateFunctions';
 
 export interface Tab {
     content: ReactNode;
@@ -13,6 +14,7 @@ export interface TabsProps {
     hasFullWidthTabHeaders?: boolean;
     hasPadding?: boolean;
     initiallyActiveTabIndex?: number;
+    isChangeTabAllowed?: boolean;
     isSmall?: boolean;
     onClickTab?: (event: SyntheticEvent, tabIndex: number) => void;
     tabs: Tab[];
@@ -31,6 +33,7 @@ export const Tabs: FunctionComponent<TabsProps> = ({
     hasFullWidthTabHeaders = true,
     hasPadding = false,
     initiallyActiveTabIndex,
+    isChangeTabAllowed = true,
     isSmall = false,
     onClickTab,
     tabs,
@@ -38,7 +41,7 @@ export const Tabs: FunctionComponent<TabsProps> = ({
     const [activeTabIndex, setActiveTabIndex] = useState(getInitiallyActiveTabIndex(tabs, initiallyActiveTabIndex));
 
     useEffect(() => {
-        if (initiallyActiveTabIndex) {
+        if (!isEmpty(initiallyActiveTabIndex)) {
             setActiveTabIndex(getInitiallyActiveTabIndex(tabs, initiallyActiveTabIndex));
         }
     }, [initiallyActiveTabIndex]);
@@ -55,7 +58,9 @@ export const Tabs: FunctionComponent<TabsProps> = ({
                             // eslint-disable-next-line react/no-array-index-key
                             key={index}
                             onClick={(event: SyntheticEvent): void => {
-                                setActiveTabIndex(index);
+                                if (isChangeTabAllowed) {
+                                    setActiveTabIndex(index);
+                                }
 
                                 if (onClickTab) {
                                     onClickTab(event, index);


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1095

**Description of the pull request**:
- add props isChangeTabAllowed and only switch tab inside the component if it is true
- initiallyActiveTabIndex can be zero

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
