### PR TITLE
Added negative coloring for currency input

### DIFF
--- a/src/app/components/molecules/Input/Input.sc.ts
+++ b/src/app/components/molecules/Input/Input.sc.ts
@@ -76,7 +76,6 @@ StyledInput.defaultProps = {
 
 interface TextFieldProps extends StyledInputBaseProps {
     adornmentPosition: AdornmentPosition;
-    colorNegativeAmount: string;
     hasAdornment: boolean;
     hasNegativeAmountColor: boolean;
     isHovered: boolean;
@@ -92,10 +91,10 @@ export const TextField = styled.input<TextFieldProps>`
     width: 100%;
     color: ${({ theme }): string => theme.colorTextBody.primary};
 
-    ${({ colorNegativeAmount, hasNegativeAmountColor }): SimpleInterpolation =>
+    ${({ hasNegativeAmountColor, theme }): SimpleInterpolation =>
         hasNegativeAmountColor &&
         css`
-            color: ${colorNegativeAmount};
+            color: ${theme.colorInvalid};
         `}
 
     ${({ adornmentPosition, hasAdornment, theme }): SimpleInterpolation =>

--- a/src/app/components/molecules/Input/Input.sc.ts
+++ b/src/app/components/molecules/Input/Input.sc.ts
@@ -76,7 +76,9 @@ StyledInput.defaultProps = {
 
 interface TextFieldProps extends StyledInputBaseProps {
     adornmentPosition: AdornmentPosition;
+    colorNegativeAmount: string;
     hasAdornment: boolean;
+    hasNegativeAmountColor: boolean;
     isHovered: boolean;
     isTextarea: boolean;
     type: InputType;
@@ -89,6 +91,12 @@ export const TextField = styled.input<TextFieldProps>`
     background-color: transparent;
     width: 100%;
     color: ${({ theme }): string => theme.colorTextBody.primary};
+
+    ${({ colorNegativeAmount, hasNegativeAmountColor }): SimpleInterpolation =>
+        hasNegativeAmountColor &&
+        css`
+            color: ${colorNegativeAmount};
+        `}
 
     ${({ adornmentPosition, hasAdornment, theme }): SimpleInterpolation =>
         hasAdornment &&

--- a/src/app/components/molecules/Input/Input.stories.tsx
+++ b/src/app/components/molecules/Input/Input.stories.tsx
@@ -15,6 +15,7 @@ export const Configurable: FunctionComponent = () => {
             autoFocus={boolean('Auto focus', true)}
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
             isTextarea={boolean('Is textarea', false)}
@@ -45,6 +46,7 @@ export const ConfigurableWithAdornment: FunctionComponent = () => {
             adornmentPosition={select('Adornment Position', AdornmentPosition, AdornmentPosition.LEFT)}
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
             isTextarea={boolean('Is textarea', false)}
@@ -72,6 +74,7 @@ export const ConfigurableClickable: FunctionComponent = () => {
         <Input
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
             isTextarea={boolean('Is textarea', false)}
@@ -100,6 +103,7 @@ export const ConfigurableMinNumberAndRequired: FunctionComponent = () => {
         <Input
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', true)}
             isValid={boolean('Is valid', false)}
@@ -125,6 +129,7 @@ export const ConfigurableMinAndMaxNumbers: FunctionComponent = () => {
         <Input
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
             isValid={boolean('Is valid', false)}
@@ -151,6 +156,7 @@ export const ConfigurableAddress: FunctionComponent = () => {
         <Input
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isValid={boolean('Is valid', false)}
             label={text('Label', 'This input has an empty string and maxlength')}
@@ -174,6 +180,7 @@ export const ConfigurableTextarea: FunctionComponent = () => {
         <Input
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
             isTextarea
@@ -201,6 +208,7 @@ export const ConfigurableTextareaClickable: FunctionComponent = () => {
         <Input
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
             isTextarea

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -20,7 +20,6 @@ import React, {
     useEffect,
     useState,
 } from 'react';
-import { COLOR_NEGATIVE_AMOUNT } from '../../../styles/constants';
 import { DEFAULT_LOCALE } from '../../../../global/constants';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import FormElementLabel from '../FormElementLabel/FormElementLabel';
@@ -32,7 +31,6 @@ export interface InputProps {
     autoFocus?: boolean;
     children?: never;
     className?: string;
-    colorNegativeAmount?: string;
     errorMessage?: ReactNode;
     hasError?: boolean;
     hasNegativeAmountColor?: boolean;
@@ -64,7 +62,6 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     adornmentPosition = AdornmentPosition.LEFT,
     autoFocus = false,
     className,
-    colorNegativeAmount = COLOR_NEGATIVE_AMOUNT,
     errorMessage,
     hasError = false,
     hasNegativeAmountColor = true,
@@ -194,8 +191,6 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
         setIsHovered(!isHovered);
     }, [isHovered]);
 
-    console.log('hasNegativeAmountColor', hasNegativeAmountColor, inputValue, toNumber(inputValue) < 0);
-
     return (
         <>
             <StyledInput
@@ -213,7 +208,6 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     adornmentPosition={adornmentPosition}
                     as={isTextarea ? 'textarea' : 'input'}
                     autoFocus={autoFocus}
-                    colorNegativeAmount={colorNegativeAmount}
                     hasAdornment={adornment !== undefined}
                     hasError={hasError || !isValidInputData}
                     hasNegativeAmountColor={hasNegativeAmountColor && !isEmpty(inputValue) && toNumber(inputValue) < 0}

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -20,6 +20,7 @@ import React, {
     useEffect,
     useState,
 } from 'react';
+import { COLOR_NEGATIVE_AMOUNT } from '../../../styles/constants';
 import { DEFAULT_LOCALE } from '../../../../global/constants';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import FormElementLabel from '../FormElementLabel/FormElementLabel';
@@ -31,8 +32,10 @@ export interface InputProps {
     autoFocus?: boolean;
     children?: never;
     className?: string;
+    colorNegativeAmount?: string;
     errorMessage?: ReactNode;
     hasError?: boolean;
+    hasNegativeAmountColor?: boolean;
     ignoreOutlineVariant?: boolean;
     isDisabled?: boolean;
     isRequired?: boolean;
@@ -61,8 +64,10 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     adornmentPosition = AdornmentPosition.LEFT,
     autoFocus = false,
     className,
+    colorNegativeAmount = COLOR_NEGATIVE_AMOUNT,
     errorMessage,
     hasError = false,
+    hasNegativeAmountColor = true,
     ignoreOutlineVariant = false,
     isDisabled = false,
     isRequired = false,
@@ -189,6 +194,8 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
         setIsHovered(!isHovered);
     }, [isHovered]);
 
+    console.log('hasNegativeAmountColor', hasNegativeAmountColor, inputValue, toNumber(inputValue) < 0);
+
     return (
         <>
             <StyledInput
@@ -206,8 +213,10 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     adornmentPosition={adornmentPosition}
                     as={isTextarea ? 'textarea' : 'input'}
                     autoFocus={autoFocus}
+                    colorNegativeAmount={colorNegativeAmount}
                     hasAdornment={adornment !== undefined}
                     hasError={hasError || !isValidInputData}
+                    hasNegativeAmountColor={hasNegativeAmountColor && !isEmpty(inputValue) && toNumber(inputValue) < 0}
                     isDisabled={isDisabled}
                     isFocused={isFocused}
                     isHovered={isHovered}

--- a/src/app/components/organisms/InputCurrency/InputCurrency.stories.tsx
+++ b/src/app/components/organisms/InputCurrency/InputCurrency.stories.tsx
@@ -14,9 +14,10 @@ export const Configurable: FunctionComponent = () => {
             adornmentPosition={select('Adornment Position', AdornmentPosition, AdornmentPosition.LEFT)}
             errorMessage={text('Error message', 'Invalid currency!')}
             hasError={boolean('Has error', false)}
-            hasValidColor={boolean('Has valid color', false)}
+            hasNegativeAmountColor={boolean('Has Negative Amount Color', true)}
             isDisabled={boolean('Is disabled', false)}
             isRequired={boolean('Is required', false)}
+            isValid={boolean('Is valid', false)}
             label={text('Label', 'Amount')}
             locale={select('Locale', Locale, Locale.NL)}
             name="a-inputcurrency-name"

--- a/src/app/components/organisms/InputCurrency/InputCurrency.tsx
+++ b/src/app/components/organisms/InputCurrency/InputCurrency.tsx
@@ -11,9 +11,10 @@ export interface InputCurrencyProps extends InputProps {
     className?: string;
     errorMessage?: ReactNode;
     hasError?: boolean;
-    hasValidColor?: boolean;
+    hasNegativeAmountColor?: boolean;
     isDisabled?: boolean;
     isRequired?: boolean;
+    isValid?: boolean;
     label?: ReactNode;
     locale: Locale;
     name: string;
@@ -27,9 +28,10 @@ export const InputCurrency: FunctionComponent<InputCurrencyProps> = ({
     className,
     errorMessage,
     hasError = false,
-    hasValidColor = false,
+    hasNegativeAmountColor = true,
     isDisabled = false,
     isRequired = false,
+    isValid = false,
     label,
     locale,
     max,
@@ -50,9 +52,10 @@ export const InputCurrency: FunctionComponent<InputCurrencyProps> = ({
             className={className}
             errorMessage={errorMessage}
             hasError={hasError}
+            hasNegativeAmountColor={hasNegativeAmountColor}
             isDisabled={isDisabled}
             isRequired={isRequired}
-            isValid={hasValidColor}
+            isValid={isValid}
             label={label}
             locale={locale}
             max={max}

--- a/src/app/components/organisms/Table/ContentCell/ContentCell.tsx
+++ b/src/app/components/organisms/Table/ContentCell/ContentCell.tsx
@@ -2,6 +2,7 @@ import { AmountWrapper, ImageWrapper, StyledContentCell } from './ContentCell.sc
 import { formatDate, formatTime, isValidClockTime, isValidDate } from '../../../../utils/functions/dateFunctions';
 import moment, { Moment } from 'moment';
 import React, { FunctionComponent, ReactNode } from 'react';
+import { COLOR_NEGATIVE_AMOUNT } from '../../../../styles/constants';
 import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import { formatMoney } from '../../../../utils/functions/financialFunctions';
 import { Locale } from '../../../../types';
@@ -23,7 +24,7 @@ export interface ContentCellProps {
 }
 
 export const ContentCell: FunctionComponent<ContentCellProps> = ({
-    colorNegativeAmount = 'red',
+    colorNegativeAmount = COLOR_NEGATIVE_AMOUNT,
     textLinesLimit = 2,
     hasLineThrough = false,
     hasTooltip = false,

--- a/src/app/styles/constants.ts
+++ b/src/app/styles/constants.ts
@@ -1,1 +1,0 @@
-export const COLOR_NEGATIVE_AMOUNT = 'red';

--- a/src/app/styles/constants.ts
+++ b/src/app/styles/constants.ts
@@ -1,0 +1,1 @@
+export const COLOR_NEGATIVE_AMOUNT = 'red';


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
*https://jira.sportlink.nl/browse/CW-1167*

**Description of the pull request**:
*- optional negative color for currency input*
*- the color is also adjustable, but has a sane default*

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
