### PR TITLE
Fb cw 1168 styling currency in column

### DIFF
--- a/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.sc.ts
+++ b/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.sc.ts
@@ -22,7 +22,7 @@ export const StyledSelectionControlGroup = styled.div<StyledSelectionControlGrou
             border: 1px solid
                 ${getBorderColor({
                     hasError,
-                    isDisabled: isDisabled || variant === SelectionControlGroupVariant.OUTLINE,
+                    isDisabled: isDisabled || variant === SelectionControlGroupVariant.OUTLINE_CHOICE,
                     theme,
                 })};
             /* stylelint-enable indentation */

--- a/src/app/components/organisms/Table/ContentCell/ContentCell.sc.ts
+++ b/src/app/components/organisms/Table/ContentCell/ContentCell.sc.ts
@@ -44,6 +44,10 @@ export const StyledContentCell = styled.div<StyledContentCellProps>`
     ${({ isCurrency }): SimpleInterpolation =>
         isCurrency &&
         css`
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
             text-align: end;
         `}
 

--- a/src/app/components/organisms/Table/ContentCell/ContentCell.tsx
+++ b/src/app/components/organisms/Table/ContentCell/ContentCell.tsx
@@ -1,9 +1,10 @@
 import { AmountWrapper, ImageWrapper, StyledContentCell } from './ContentCell.sc';
 import { formatDate, formatTime, isValidClockTime, isValidDate } from '../../../../utils/functions/dateFunctions';
+import { formatMoneyWithoutSymbol, getCurrencyIcon } from '../../../../utils/functions/financialFunctions';
 import moment, { Moment } from 'moment';
 import React, { FunctionComponent, ReactNode } from 'react';
 import { DEFAULT_LOCALE } from '../../../../../global/constants';
-import { formatMoney } from '../../../../utils/functions/financialFunctions';
+import Icon from '../../../atoms/Icon/Icon';
 import { Locale } from '../../../../types';
 
 export interface ContentCellProps {
@@ -45,9 +46,12 @@ export const ContentCell: FunctionComponent<ContentCellProps> = ({
 
     if (isCurrency) {
         content = typeof value === 'number' && (
-            <AmountWrapper hasNegativeAmountColor={hasNegativeAmountColor && value < 0}>
-                {formatMoney(value, locale)}
-            </AmountWrapper>
+            <>
+                <Icon type={getCurrencyIcon(locale)} />
+                <AmountWrapper hasNegativeAmountColor={hasNegativeAmountColor && value < 0}>
+                    {formatMoneyWithoutSymbol(value, locale)}
+                </AmountWrapper>
+            </>
         );
     }
 

--- a/src/app/components/organisms/Table/mockup/tableData.ts
+++ b/src/app/components/organisms/Table/mockup/tableData.ts
@@ -37,7 +37,7 @@ export const tableData = (): TableData[] => {
     const result = makeTableData(100);
 
     result.push({
-        amount: 0,
+        amount: -120,
         companyName: 'Dexels',
         firstName: 'Anna',
         id: '186',

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -394,7 +394,7 @@ export enum Position {
 export enum SelectionControlGroupVariant {
     COMPACT = 'COMPACT',
     OUTLINE = 'OUTLINE',
-    OUTLINE_INPUT = 'OUTLINE_INPUT',
+    OUTLINE_CHOICE = 'OUTLINE_CHOICE',
 }
 
 export enum SidePanelSize {


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
*https://jira.sportlink.nl/browse/CW-1168*

**Description of the pull request**:
*- style currency column so the symbol is on the left and the amount on the right*

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
