### PR TITLE
add wrapper because the label element is positioned absolutely

### DIFF
--- a/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.sc.ts
+++ b/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.sc.ts
@@ -3,6 +3,9 @@ import styled, { css, SimpleInterpolation } from 'styled-components';
 import { getBorderColor } from '../../../styles/mixins/getBorderColor';
 import { themeBasic } from '../../../styles/theming/themes/basic';
 
+export const SelectedControlGroupWrapper = styled.div`
+    position: relative;
+`;
 interface StyledSelectionControlGroupProps {
     alignment: Alignment;
     hasError: boolean;

--- a/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.tsx
+++ b/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.tsx
@@ -1,6 +1,7 @@
 import { Alignment, Direction, OptionObject, SelectionControlGroupVariant } from '../../../types';
 import React, { FunctionComponent, ReactNode, useCallback, useEffect, useState } from 'react';
 import {
+    SelectedControlGroupWrapper,
     SelectionControlWrapper,
     StyledSelectionControlGroup,
     StyledSelectionControls,
@@ -67,7 +68,7 @@ export const SelectionControlGroup: FunctionComponent<SelectionControlGroupProps
     }, [defaultValue, isRequired, options, selectedValue]);
 
     return (
-        <>
+        <SelectedControlGroupWrapper>
             {title && variant !== SelectionControlGroupVariant.COMPACT ? (
                 <FormElementLabel hasError={hasError} isDisabled={isDisabled}>
                     {title}
@@ -116,7 +117,7 @@ export const SelectionControlGroup: FunctionComponent<SelectionControlGroupProps
                     ))}
                 </StyledSelectionControls>
             </StyledSelectionControlGroup>
-        </>
+        </SelectedControlGroupWrapper>
     );
 };
 


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

- added a wrapper because the label element has position:absolute rule it should be inside another element with position relative.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
