### PR TITLE
style rules needed to overridde overflow:visible overriding radius co…

### DIFF
--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -139,11 +139,17 @@ Header.defaultProps = {
 
 interface BodyProps {
     hasBodyPadding: boolean;
+    hasBorderRadius: boolean;
 }
 
 export const Body = styled.div<BodyProps>`
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
+    ${({ hasBorderRadius }): SimpleInterpolation =>
+        hasBorderRadius &&
+        css`
+            border-top-left-radius: inherit;
+            border-top-right-radius: inherit;
+        `}
+
     background-color: ${({ theme }): string => theme.card.backgroundColor};
 
     ${({ hasBodyPadding, theme }): SimpleInterpolation =>

--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -120,6 +120,8 @@ interface HeaderProps {
 
 export const Header = styled.header<HeaderProps>`
     ${({ theme }): string => theme.textStyling(theme.availableTextStyles().h1)}
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
     background-color: ${({ theme }): string => theme.colorPrimary};
     min-height: ${({ theme }): string => theme.spacing(7)};
     color: ${({ theme }): string => theme.colorTextContrast.primary};
@@ -140,6 +142,8 @@ interface BodyProps {
 }
 
 export const Body = styled.div<BodyProps>`
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
     background-color: ${({ theme }): string => theme.card.backgroundColor};
 
     ${({ hasBodyPadding, theme }): SimpleInterpolation =>

--- a/src/app/components/organisms/Dialog/Dialog.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.tsx
@@ -17,6 +17,7 @@ import { IconCustomizable, IconCustomizableSize } from '../../molecules/IconCust
 import React, { FunctionComponent, MouseEventHandler, ReactNode } from 'react';
 import { DialogButtonClosePosition } from './types';
 import { IconProps } from '../../atoms/Icon/Icon';
+import { isEmpty } from '../../../../lib';
 import Overlay from '../../molecules/Overlay/Overlay';
 
 export interface DialogProps {
@@ -84,7 +85,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
         >
             <StyledDialog elevation={elevation} isScrollable={isScrollable}>
                 {header && <Header hasHeaderPadding={hasHeaderPadding}>{header}</Header>}
-                <Body hasBodyPadding={hasBodyPadding}>
+                <Body hasBodyPadding={hasBodyPadding} hasBorderRadius={isEmpty(header)}>
                     {iconType && title && (
                         <StyledTextWithOptionalIcon iconType={iconType}>{title}</StyledTextWithOptionalIcon>
                     )}


### PR DESCRIPTION
…rners

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1180

**Description of the pull request**:
When the dialog has props isScrollable false (in case there is a datePicker in it) the dialog gets overflow:visible and it overrides the radius of the border of the parent element.
- let header inherrit radius
- let body inherit radius only when there is no header.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
