### PR TITLE
CW-1182 give InputValue first value so validation will be correct also in first render

### DIFF
--- a/src/app/components/molecules/Input/Input.sc.ts
+++ b/src/app/components/molecules/Input/Input.sc.ts
@@ -8,6 +8,7 @@ interface StyledInputBaseProps {
     hasError: boolean;
     isDisabled: boolean;
     isFocused: boolean;
+    isHovered: boolean;
     isValid: boolean;
     variant: InputVariant;
 }
@@ -39,7 +40,7 @@ export const StyledInput = styled.div<StyledInputProps>`
             }
         `}
 
-    ${({ hasError, isDisabled, isFocused, isValid, theme, variant }): SimpleInterpolation =>
+    ${({ hasError, isDisabled, isFocused, isHovered, isValid, theme, variant }): SimpleInterpolation =>
         variant === InputVariant.COMPACT &&
         css`
             &::after {
@@ -47,24 +48,18 @@ export const StyledInput = styled.div<StyledInputProps>`
                 height: 1px;
                 content: '';
 
-                ${isFocused &&
-                css`
-                    background-color: ${theme.colorSecondary};
-                `}
-
-                ${isValid &&
-                css`
-                    background-color: ${theme.colorValid};
-                `}
-
-                ${hasError &&
-                css`
-                    background-color: ${theme.colorInvalid};
-                `}
-
-                ${isDisabled &&
-                css`
-                    background-color: transparent;
+                ${css`
+                    /* stylelint-disable indentation */
+                    background-color: ${getBorderColor({
+                        defaultColor: theme.colorPrimary,
+                        hasError,
+                        isDisabled,
+                        isFocused,
+                        isHovered,
+                        isValid,
+                        theme,
+                    })};
+                    /* stylelint-enable indentation */
                 `}
             }
         `}
@@ -78,7 +73,6 @@ interface TextFieldProps extends StyledInputBaseProps {
     adornmentPosition: AdornmentPosition;
     hasAdornment: boolean;
     hasNegativeAmountColor: boolean;
-    isHovered: boolean;
     isTextarea: boolean;
     type: InputType;
 }

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -89,8 +89,8 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
 }) => {
     const [isFocused, setIsFocused] = useState(false);
     const [isHovered, setIsHovered] = useState(false);
-    const [isValidInputData, setIsValidInputData] = useState(false);
-    const [inputValue, setInputValue] = useState('');
+    const [isValidInputData, setIsValidInputData] = useState(true);
+    const [inputValue, setInputValue] = useState(value || '');
 
     // we want to be able to force re-render if the value is changed from outside the component
     useEffect(() => {
@@ -136,7 +136,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     // when inputValue changes validate it
     useEffect(() => {
         setIsValidInputData(isValidInput(inputValue || ''));
-    }, [inputValue, isRequired]);
+    }, [inputValue]);
 
     const onChangeCallback = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
@@ -199,6 +199,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                 isClickable={!isDisabled && Boolean(onClick)}
                 isDisabled={isDisabled}
                 isFocused={isFocused}
+                isHovered={isHovered}
                 isValid={isValid}
                 onClick={isDisabled || !onClick ? undefined : onClick}
                 variant={variant}

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -227,7 +227,7 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     }, [data, isEditable]);
 
     useEffect(() => {
-        if (isLoading || !data.length) {
+        if (isLoading || isEmpty(data)) {
             setInformationTableData(
                 Array(amountOfColumns * DEFAULT_AMOUNT_ROWS).fill({
                     label: <Skeleton width="60%" />,

--- a/src/app/components/organisms/InputCurrency/InputCurrency.sc.ts
+++ b/src/app/components/organisms/InputCurrency/InputCurrency.sc.ts
@@ -1,7 +1,0 @@
-import { setBoxSizing } from '../../../styles/mixins/setBoxSizing';
-import styled from 'styled-components';
-
-export const StyledInputCurrency = styled.div`
-    ${setBoxSizing()}
-    position: relative;
-`;

--- a/src/app/components/organisms/InputCurrency/InputCurrency.tsx
+++ b/src/app/components/organisms/InputCurrency/InputCurrency.tsx
@@ -3,7 +3,6 @@ import Input, { InputProps } from '../../molecules/Input/Input';
 import React, { FunctionComponent, ReactNode } from 'react';
 import { getCurrencyIcon } from '../../../utils/functions/financialFunctions';
 import { Icon } from '../../atoms/Icon/Icon';
-import { StyledInputCurrency } from './InputCurrency.sc';
 
 export interface InputCurrencyProps extends InputProps {
     adornmentPosition?: AdornmentPosition;
@@ -44,32 +43,30 @@ export const InputCurrency: FunctionComponent<InputCurrencyProps> = ({
     value,
     variant = InputVariant.OUTLINE,
 }) => (
-    <StyledInputCurrency className={className}>
-        <Input
-            adornment={<Icon type={getCurrencyIcon(locale)} />}
-            adornmentPosition={adornmentPosition}
-            autoFocus={autoFocus}
-            className={className}
-            errorMessage={errorMessage}
-            hasError={hasError}
-            hasNegativeAmountColor={hasNegativeAmountColor}
-            isDisabled={isDisabled}
-            isRequired={isRequired}
-            isValid={isValid}
-            label={label}
-            locale={locale}
-            max={max}
-            min={min}
-            name={name}
-            onBlur={onBlur}
-            onChange={onChange}
-            onFocus={onFocus}
-            onKeyDown={onKeyDown}
-            type={InputType.CURRENCY}
-            value={value}
-            variant={variant}
-        />
-    </StyledInputCurrency>
+    <Input
+        adornment={<Icon type={getCurrencyIcon(locale)} />}
+        adornmentPosition={adornmentPosition}
+        autoFocus={autoFocus}
+        className={className}
+        errorMessage={errorMessage}
+        hasError={hasError}
+        hasNegativeAmountColor={hasNegativeAmountColor}
+        isDisabled={isDisabled}
+        isRequired={isRequired}
+        isValid={isValid}
+        label={label}
+        locale={locale}
+        max={max}
+        min={min}
+        name={name}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        type={InputType.CURRENCY}
+        value={value}
+        variant={variant}
+    />
 );
 
 export default InputCurrency;


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1182

**Description of the pull request**:
- some beautifying
- give Inputvalue state variable an intial value, otherwise the first validation when the field is required always not valid, even though there is a value. that is what causes the errorMessage and red border to blink.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
