### PR TITLE
CW-1236: Hide action buttons when onSave is not set

### DIFF
--- a/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
@@ -24,7 +24,8 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
     isEditable = true,
     errors = undefined as unknown as string[],
     warnings = undefined as unknown as string[],
-    isCurrencyOnly = false
+    isCurrencyOnly = false,
+    hasSaveAction = true
 ): JSX.Element => {
     const [updatedData, setUpdatedData] = useState<EditableInformationData<T, U>>(data);
     const [isSaving, setIsSaving] = useState(false);
@@ -101,7 +102,7 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
             onCancel={onCancelCallback}
             onChange={onChangeCallback}
             onEdit={isEditable ? action('onEdit') : undefined}
-            onSave={isEditable ? onSaveCallback : undefined}
+            onSave={hasSaveAction && isEditable ? onSaveCallback : undefined}
             onValidation={isEditable ? onValidationCallback : undefined}
             saveConfirmDialog={
                 withDialogs
@@ -127,6 +128,9 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
 export const Configurable: FunctionComponent = () => BaseComponent(theData());
 
 export const ConfigurableEditingDefault: FunctionComponent = () => BaseComponent(theData(), true);
+
+export const ConfigurableEditingWithoutButtons: FunctionComponent = () =>
+    BaseComponent(theData(), true, false, true, [], [], false, false);
 
 export const ConfigurableWithConfirmationDialogs: FunctionComponent = () => BaseComponent(theData(), false, true);
 

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -294,6 +294,7 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     return onEdit || onSave ? (
         <EditablePanel
             cancelConfirmDialog={cancelConfirmDialog}
+            hasButtons={onSave !== undefined}
             hasError={hasError || !isValidInputData}
             iconCancel={iconCancel}
             iconEdit={iconEdit}

--- a/src/app/components/organisms/EditablePanel/EditablePanel.stories.tsx
+++ b/src/app/components/organisms/EditablePanel/EditablePanel.stories.tsx
@@ -71,6 +71,26 @@ export const ConfigurableIsEditingDefault: FunctionComponent = () => (
     </EditablePanel>
 );
 
+export const ConfigurableNoSaveAction: FunctionComponent = () => (
+    <EditablePanel
+        hasButtons={false}
+        iconCancel={select('Icon Cancel', IconType, IconType.CROSS)}
+        iconEdit={select('Icon Edit', IconType, IconType.PENCIL)}
+        iconSave={select('Icon Save', IconType, IconType.CHECK)}
+        iconType={select('Icon type', IconType, IconType.FLAG)}
+        isDisabled={boolean('Is disabled', false)}
+        onCancel={action('onCancel')}
+        onEdit={action('onEdit')}
+        onSave={action('onSave')}
+        textCancel={text('Text Cancel', 'Cancel')}
+        textEdit={text('Text Edit', 'Edit')}
+        textSave={text('Text Save', 'Save')}
+        title={text('Title', 'Location')}
+    >
+        <div>{'The panel has these children'}</div>
+    </EditablePanel>
+);
+
 export const ConfigurableWithConfirmationDialogs: FunctionComponent = () => (
     <EditablePanel
         cancelConfirmDialog={{

--- a/src/app/components/organisms/EditablePanel/EditablePanel.tsx
+++ b/src/app/components/organisms/EditablePanel/EditablePanel.tsx
@@ -9,6 +9,7 @@ import { Dialog } from '../Dialog';
 export interface EditablePanelProps extends Omit<PanelHeaderProps, 'children' | 'options'> {
     cancelConfirmDialog?: ConfirmDialog;
     children: ReactNode;
+    hasButtons?: boolean; // Will be derived from onSave action in parent component
     hasError?: boolean;
     iconCancel?: IconType;
     iconEdit?: IconType;
@@ -31,6 +32,7 @@ export interface EditablePanelProps extends Omit<PanelHeaderProps, 'children' | 
 export const EditablePanel: FunctionComponent<EditablePanelProps> = ({
     cancelConfirmDialog,
     children,
+    hasButtons = true,
     hasCapitalizedTitle,
     hasError = false,
     iconCancel = IconType.CROSS,
@@ -133,7 +135,8 @@ export const EditablePanel: FunctionComponent<EditablePanelProps> = ({
                 hasTitleStatusAppearance
                 iconType={iconType}
                 options={
-                    isBeingEdited ? (
+                    // eslint-disable-next-line no-nested-ternary
+                    !hasButtons ? undefined : isBeingEdited ? (
                         <ButtonWrapper>
                             <Button
                                 iconType={iconCancel}


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
*https://jira.sportlink.nl/browse/CW-1236*

**Description of the pull request**:
*- when onSave is absent, then the buttons shouldn't be visible*

This gives us the possibility of using the component inside a modal for instance

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
