### PR TITLE
Fb cw 1236 bug in directdebitauthorization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dexels-ui-kit",
-    "version": "5.25.7",
+    "version": "5.25.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dexels-ui-kit",
-    "version": "5.25.7",
+    "version": "5.25.8",
     "author": {
         "name": "Dexels B.V.",
         "email": "info@dexels.com"

--- a/src/app/__tests__/utils/functions/financialFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/financialFunctions.test.ts
@@ -1,0 +1,23 @@
+import { toCents, toMoneyValue } from '../../../utils/functions/financialFunctions';
+import { Locale } from '../../../types';
+
+describe('test financial functions', () => {
+    test('test toCents', () => {
+        expect(toCents('0.5')).toBe(50);
+        expect(toCents('0.50')).toBe(50);
+        expect(toCents('0.51')).toBe(51);
+        expect(toCents('100')).toBe(10000);
+    });
+
+    test('test toMoneyValue', () => {
+        expect(toMoneyValue('0,50', Locale.NL)).toBe(0.5);
+        expect(toMoneyValue('0,51', Locale.NL)).toBe(0.51);
+        expect(toMoneyValue('1,50', Locale.NL)).toBe(1.5);
+        expect(toMoneyValue('1.000,52', Locale.NL)).toBe(1000.52);
+
+        expect(toMoneyValue('0,.50', Locale.EN)).toBe(0.5);
+        expect(toMoneyValue('0.51', Locale.EN)).toBe(0.51);
+        expect(toMoneyValue('1.50', Locale.EN)).toBe(1.5);
+        expect(toMoneyValue('1,000.52', Locale.EN)).toBe(1000.52);
+    });
+});

--- a/src/app/__tests__/utils/functions/validateFunctions.test.ts
+++ b/src/app/__tests__/utils/functions/validateFunctions.test.ts
@@ -1,10 +1,11 @@
 import {
     isValidEmail,
     isValidIBAN,
+    isValidInputCurrency,
+    isValidMoney,
     isValidNumber,
     isValidPhoneNumber,
 } from '../../../utils/functions/validateFunctions';
-import { DEFAULT_LOCALE } from '../../../../global/constants';
 import { Locale } from '../../../types';
 
 describe('test validating functions', () => {
@@ -39,19 +40,32 @@ describe('test validating functions', () => {
         expect(isValidNumber('1.09', false)).toBe(false);
         expect(isValidNumber('1.09', true)).toBe(false);
         expect(isValidNumber('1.09', true, 'EN' as Locale)).toBe(true);
+        expect(isValidNumber('1.', true)).toBeFalsy();
+        expect(isValidNumber('1.0', true)).toBeFalsy();
+        expect(isValidNumber('1.00', true)).toBeFalsy();
+        expect(isValidNumber('1.000', true)).toBeTruthy();
     });
 
     test('isValidPhoneNumber', () => {
         expect(isValidPhoneNumber('061234567')).toBe(true);
         expect(isValidPhoneNumber('061234567a')).toBe(true);
-        expect(isValidPhoneNumber('061234567', DEFAULT_LOCALE)).toBe(false);
-        expect(isValidPhoneNumber('061234567a', DEFAULT_LOCALE)).toBe(false);
-        expect(isValidPhoneNumber('0612345678', DEFAULT_LOCALE)).toBe(true);
-        expect(isValidPhoneNumber('06 12345678', DEFAULT_LOCALE)).toBe(true);
-        expect(isValidPhoneNumber('06-12345678', DEFAULT_LOCALE)).toBe(true);
-        expect(isValidPhoneNumber('020-1234567', DEFAULT_LOCALE)).toBe(true);
-        expect(isValidPhoneNumber('0299-123456', DEFAULT_LOCALE)).toBe(true);
-        expect(isValidPhoneNumber('020 - 1234567', DEFAULT_LOCALE)).toBe(false);
-        expect(isValidPhoneNumber('06 - 12345678', DEFAULT_LOCALE)).toBe(false);
+        expect(isValidPhoneNumber('061234567', Locale.NL)).toBe(false);
+        expect(isValidPhoneNumber('061234567a', Locale.NL)).toBe(false);
+        expect(isValidPhoneNumber('0612345678', Locale.NL)).toBe(true);
+        expect(isValidPhoneNumber('06 12345678', Locale.NL)).toBe(true);
+        expect(isValidPhoneNumber('06-12345678', Locale.NL)).toBe(true);
+        expect(isValidPhoneNumber('020-1234567', Locale.NL)).toBe(true);
+        expect(isValidPhoneNumber('0299-123456', Locale.NL)).toBe(true);
+        expect(isValidPhoneNumber('020 - 1234567', Locale.NL)).toBe(false);
+        expect(isValidPhoneNumber('06 - 12345678', Locale.NL)).toBe(false);
+    });
+
+    test('test isValidInputCurrency', () => {
+        expect(isValidInputCurrency('0,51', Locale.NL, false)).toBeTruthy();
+    });
+
+    test('test isValidMoney', () => {
+        expect(isValidMoney('1.', Locale.NL)).toBeFalsy();
+        expect(isValidInputCurrency('1.000', Locale.NL, false)).toBeTruthy();
     });
 });

--- a/src/app/components/molecules/DialogFooter/DialogFooter.sc.ts
+++ b/src/app/components/molecules/DialogFooter/DialogFooter.sc.ts
@@ -21,6 +21,7 @@ export const Text = styled.p`
     ${({ theme }): string => theme.textStyling(theme.availableTextStyles().caption)}
     margin: 0;
     padding: ${({ theme }): string => theme.spacing(0, 2, 0, 0)};
+    width: 100%;
     word-break: break-word;
     color: ${({ theme }): string => theme.colorText.primary};
 `;
@@ -43,7 +44,7 @@ export const ButtonWrapper = styled.div<ButtonWrapperProps>`
     align-items: center;
     margin: ${({ alignment, theme }): string =>
         theme.spacing(0, alignment === Alignment.LEFT ? 0.5 : 1, 0, alignment === Alignment.LEFT ? 0 : 1)};
-    min-height: 32px;
+    min-height: ${({ theme }): string => theme.spacing(4)};
     vertical-align: middle;
     ${({ alignment }) => alignment === Alignment.LEFT && 'float: left;'}
 

--- a/src/app/components/molecules/Input/Input.sc.ts
+++ b/src/app/components/molecules/Input/Input.sc.ts
@@ -1,10 +1,10 @@
-import { AdornmentPosition, InputType, InputVariant } from '../../../types';
+import { AdornmentPosition, InputVariant } from '../../../types';
 import styled, { css, SimpleInterpolation } from 'styled-components';
 import { getBorderColor } from '../../../styles/mixins/getBorderColor';
 import { setBoxSizing } from '../../../styles/mixins/setBoxSizing';
 import { themeBasic } from '../../../styles/theming/themes/basic';
 
-interface StyledInputBaseProps {
+export interface StyledInputBaseProps {
     hasError: boolean;
     isDisabled: boolean;
     isFocused: boolean;
@@ -70,87 +70,6 @@ export const StyledInput = styled.div<StyledInputProps>`
 `;
 
 StyledInput.defaultProps = {
-    theme: themeBasic,
-};
-
-interface TextFieldProps extends StyledInputBaseProps {
-    adornmentPosition: AdornmentPosition;
-    hasAdornment: boolean;
-    hasNegativeAmountColor: boolean;
-    isTextarea: boolean;
-    type: InputType;
-}
-
-export const TextField = styled.input<TextFieldProps>`
-    ${({ theme }): string => theme.textStyling(theme.availableTextStyles().body1)}
-    display: block;
-    outline: none;
-    background-color: transparent;
-    width: 100%;
-    color: ${({ theme }): string => theme.colorTextBody.primary};
-
-    ${({ hasNegativeAmountColor, theme }): SimpleInterpolation =>
-        hasNegativeAmountColor &&
-        css`
-            color: ${theme.colorInvalid};
-        `}
-
-    ${({ adornmentPosition, hasAdornment, theme }): SimpleInterpolation =>
-        hasAdornment &&
-        adornmentPosition === AdornmentPosition.LEFT &&
-        css`
-            text-indent: ${theme.spacing(2)};
-        `}
-
-    ${({ theme, variant }): SimpleInterpolation =>
-        variant === InputVariant.COMPACT &&
-        css`
-            border: 0;
-            border-bottom: 1px solid;
-            padding: 0;
-            height: ${theme.spacing(3.5)};
-        `}
-
-    ${({ theme, variant }): SimpleInterpolation =>
-        variant === InputVariant.OUTLINE &&
-        css`
-            border: 1px solid;
-            border-radius: ${theme.spacing(1)};
-            padding: ${theme.spacing(0, 1.5)};
-            height: ${theme.spacing(6)};
-        `}
-
-    ${({ isTextarea, theme }): SimpleInterpolation =>
-        isTextarea &&
-        css`
-            padding: ${theme.spacing(1.5)};
-            height: ${theme.spacing(16)};
-            resize: none;
-        `}
-
-    ${({ isDisabled, theme }): SimpleInterpolation =>
-        isDisabled &&
-        css`
-            color: ${theme.colorDisabled};
-        `}
-
-    ${({ hasError, isDisabled, isFocused, isHovered, isValid, theme }): SimpleInterpolation =>
-        css`
-            /* stylelint-disable indentation */
-            border-color: ${getBorderColor({
-                defaultColor: theme.colorPrimary,
-                hasError,
-                isDisabled,
-                isFocused,
-                isHovered,
-                isValid,
-                theme,
-            })};
-            /* stylelint-enable indentation */
-        `}
-`;
-
-TextField.defaultProps = {
     theme: themeBasic,
 };
 

--- a/src/app/components/molecules/Input/Input.sc.ts
+++ b/src/app/components/molecules/Input/Input.sc.ts
@@ -135,7 +135,8 @@ export const AdornmentWrapper = styled.div<AdornmentWrapperProps>`
             color: ${theme.colorDisabled};
         `}
 
-    ${({ isFocused, isHovered, theme }): SimpleInterpolation =>
+    ${({ hasError, isFocused, isHovered, theme }): SimpleInterpolation =>
+        !hasError &&
         (isFocused || isHovered) &&
         css`
             color: ${theme.colorSecondary};

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -1,5 +1,5 @@
 import { AdornmentPosition, InputType, InputVariant, Locale } from '../../../types';
-import { AdornmentWrapper, StyledInput, TextField } from './Input.sc';
+import { AdornmentWrapper, StyledInput } from './Input.sc';
 import { formatMoneyWithoutSymbol, toCents, toMoneyValue } from '../../../utils/functions/financialFunctions';
 import {
     isEmpty,
@@ -23,6 +23,7 @@ import React, {
 import { DEFAULT_LOCALE } from '../../../../global/constants';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import FormElementLabel from '../FormElementLabel/FormElementLabel';
+import { TextField } from './component/TextField.sc';
 import toNumber from '../../../utils/functions/toNumber';
 
 export interface InputProps {

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -37,6 +37,7 @@ export interface InputProps {
     hasNegativeAmountColor?: boolean;
     ignoreOutlineVariant?: boolean;
     isDisabled?: boolean;
+    isOnChangeRequired?: boolean;
     isRequired?: boolean;
     isTextarea?: boolean;
     isValid?: boolean;
@@ -69,6 +70,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     ignoreOutlineVariant = false,
     isDisabled = false,
     isRequired = false,
+    isOnChangeRequired = true,
     isTextarea = false,
     isValid = false,
     label,
@@ -91,8 +93,9 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     const [isFocused, setIsFocused] = useState(false);
     const [isHovered, setIsHovered] = useState(false);
     const [isValidInputData, setIsValidInputData] = useState(true);
-    const [inputValue, setInputValue] = useState('');
-    const hasValue = !isEmpty(inputValue);
+    const [inputDisplayValue, setInputDisplayValue] = useState('');
+    const [inputValue, setInputValue] = useState(''); // for currency for disabling save button purposes onnly
+    const hasValue = !isEmpty(inputDisplayValue);
     const textFieldProps: { [key: string]: number } = {};
 
     // Because this check might be performed in several actions, put it here
@@ -121,86 +124,124 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
         [isRequired, locale, max, maxLength, min, minLength, type]
     );
 
+    const checkRange = useCallback(
+        (valueToCheck: string): string => {
+            let newValue = valueToCheck;
+
+            if (max !== undefined && valueToCheck && toNumber(valueToCheck) > max) {
+                newValue = max.toString();
+            }
+
+            if (min !== undefined && valueToCheck && toNumber(valueToCheck) < min) {
+                newValue = min.toString();
+            }
+
+            return newValue;
+        },
+        [min, max]
+    );
+
     const onChangeCallback = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
             let newValue = event.currentTarget.value;
 
             if (type !== InputType.CURRENCY) {
                 // for currency no manipulation of the value before loosing focus
-
                 if (!isTextarea) {
-                    if (max !== undefined && newValue && toNumber(newValue) > max) {
-                        newValue = max.toString();
-                    }
-
-                    if (min !== undefined && newValue && toNumber(newValue) < min) {
-                        newValue = min.toString();
-                    }
-                }
-
-                if (onChange) {
-                    onChange({
-                        ...event,
-                        currentTarget: {
-                            name: event.currentTarget.name,
-                            value: newValue,
-                        },
-                    } as ChangeEvent<HTMLInputElement>);
+                    newValue = checkRange(newValue);
                 }
             }
 
-            setInputValue(newValue);
+            setInputDisplayValue(newValue);
+
+            // prepare value for calling extern onChange
+            if (type === InputType.CURRENCY) {
+                newValue = toMoneyValue(newValue, locale).toString();
+                setInputValue(newValue);
+            }
+
+            if (onChange && (type !== InputType.CURRENCY || isOnChangeRequired)) {
+                onChange({
+                    ...event,
+                    currentTarget: {
+                        name: event.currentTarget.name,
+                        value: newValue,
+                    },
+                } as ChangeEvent<HTMLInputElement>);
+            }
         },
         [onChange]
     );
 
-    const toggleIsFocusedCallback = useCallback(
+    const onFocusCallback = useCallback(
         (event: FocusEvent<HTMLInputElement>) => {
-            if (onFocus && !isFocused) {
+            setIsFocused(true);
+
+            if (onFocus) {
                 onFocus(event);
             }
-
-            if (isFocused && onBlur) {
-                // Perform some possible post actions
-                if (type === InputType.CURRENCY && isValidInputData) {
-                    // setInputValue(formatMoneyWithoutSymbol(inputValue || '', locale));
-                    // @TODO something that adds the cents correctly
-
-                    if (onChange) {
-                        onChange({
-                            currentTarget: {
-                                name,
-                                value: toMoneyValue(inputValue, locale).toString(),
-                            },
-                        } as ChangeEvent<HTMLInputElement>);
-                    }
-                }
-
-                onBlur(event);
-            }
-
-            setIsFocused(!isFocused);
         },
-        [inputValue, isFocused, isValidInputData, onBlur, onChange, onFocus]
+        [onFocus]
     );
 
-    const toggleIsHoveredCallback = useCallback(() => {
+    const onBlurCallback = useCallback(
+        (event: FocusEvent<HTMLInputElement>) => {
+            setIsFocused(false);
+
+            // Perform some possible post actions
+            if (type === InputType.CURRENCY) {
+                const newValue = checkRange(inputValue);
+
+                setInputValue(newValue);
+
+                // if onChange is not required then it wasn't fined on change and needs to be fired onBlur
+                if (onChange && !isOnChangeRequired) {
+                    onChange({
+                        currentTarget: {
+                            name,
+                            value: newValue,
+                        },
+                    } as ChangeEvent<HTMLInputElement>);
+                }
+
+                if (onBlur) {
+                    onBlur({
+                        currentTarget: {
+                            name,
+                            value: newValue,
+                        },
+                    } as FocusEvent<HTMLInputElement>);
+                }
+            } else if (onBlur) {
+                onBlur(event);
+            }
+        },
+        [inputDisplayValue, inputValue, name, onBlur, onChange, type]
+    );
+
+    const onHoveredCallback = useCallback(() => {
         setIsHovered(!isHovered);
     }, [isHovered]);
 
     // we want to be able to force re-render if the value is changed from outside the component
     useEffect(() => {
         if (type === InputType.CURRENCY) {
-            setInputValue(formatMoneyWithoutSymbol(toMoneyValue(toCents(value || ''), locale, true), locale));
+            setInputDisplayValue(formatMoneyWithoutSymbol(toMoneyValue(toCents(value || ''), locale, true), locale));
         } else {
-            setInputValue(value || '');
+            setInputDisplayValue(value || '');
         }
     }, [value]);
 
-    // when inputValue changes validate it
     useEffect(() => {
-        setIsValidInputData(isValidInput(inputValue));
-    }, [inputValue]);
+        // for currency also check the temporary inputValue
+        const validation =
+            type === InputType.CURRENCY
+                ? isValidInput(inputDisplayValue) &&
+                  (isEmpty(inputValue) || isValidInputNumber(inputValue, locale, isRequired, min, max))
+                : isValidInput(inputDisplayValue);
+
+        setIsValidInputData(validation);
+    }, [inputDisplayValue, inputValue]);
 
     return (
         <>
@@ -222,7 +263,9 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     autoFocus={autoFocus}
                     hasAdornment={adornment !== undefined}
                     hasError={hasError || !isValidInputData}
-                    hasNegativeAmountColor={hasNegativeAmountColor && !isEmpty(inputValue) && toNumber(inputValue) < 0}
+                    hasNegativeAmountColor={
+                        hasNegativeAmountColor && !isEmpty(inputDisplayValue) && toNumber(inputDisplayValue) < 0
+                    }
                     isDisabled={isDisabled}
                     isFocused={isFocused}
                     isHovered={isHovered}
@@ -231,15 +274,15 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     maxLength={maxLength}
                     minLength={minLength}
                     name={name}
-                    onBlur={isDisabled ? undefined : toggleIsFocusedCallback}
+                    onBlur={isDisabled ? undefined : onBlurCallback}
                     onChange={isDisabled ? undefined : onChangeCallback}
-                    onFocus={isDisabled ? undefined : toggleIsFocusedCallback}
+                    onFocus={isDisabled ? undefined : onFocusCallback}
                     onKeyDown={isDisabled || !onKeyDown ? undefined : onKeyDown}
-                    onMouseEnter={isDisabled ? undefined : toggleIsHoveredCallback}
-                    onMouseLeave={isDisabled ? undefined : toggleIsHoveredCallback}
+                    onMouseEnter={isDisabled ? undefined : onHoveredCallback}
+                    onMouseLeave={isDisabled ? undefined : onHoveredCallback}
                     readOnly={isDisabled}
                     type={type}
-                    value={inputValue}
+                    value={inputDisplayValue}
                     variant={variant}
                     {...textFieldProps}
                 />

--- a/src/app/components/molecules/Input/component/TextField.sc.ts
+++ b/src/app/components/molecules/Input/component/TextField.sc.ts
@@ -1,0 +1,86 @@
+import { AdornmentPosition, InputType, InputVariant } from '../../../../types';
+import styled, { css, SimpleInterpolation } from 'styled-components';
+import { getBorderColor } from '../../../../styles/mixins/getBorderColor';
+import { StyledInputBaseProps } from '../Input.sc';
+import { themeBasic } from '../../../../styles/theming/themes/basic';
+
+interface TextFieldProps extends StyledInputBaseProps {
+    adornmentPosition: AdornmentPosition;
+    hasAdornment: boolean;
+    hasNegativeAmountColor: boolean;
+    isTextarea: boolean;
+    type: InputType;
+}
+
+export const TextField = styled.input<TextFieldProps>`
+    ${({ theme }): string => theme.textStyling(theme.availableTextStyles().body1)}
+    display: block;
+    outline: none;
+    background-color: transparent;
+    width: 100%;
+    color: ${({ theme }): string => theme.colorTextBody.primary};
+
+    ${({ hasNegativeAmountColor, theme }): SimpleInterpolation =>
+        hasNegativeAmountColor &&
+        css`
+            color: ${theme.colorInvalid};
+        `}
+
+    ${({ adornmentPosition, hasAdornment, theme }): SimpleInterpolation =>
+        hasAdornment &&
+        adornmentPosition === AdornmentPosition.LEFT &&
+        css`
+            text-indent: ${theme.spacing(2)};
+        `}
+
+    ${({ theme, variant }): SimpleInterpolation =>
+        variant === InputVariant.COMPACT &&
+        css`
+            border: 0;
+            border-bottom: 1px solid;
+            padding: 0;
+            height: ${theme.spacing(3.5)};
+        `}
+
+    ${({ theme, variant }): SimpleInterpolation =>
+        variant === InputVariant.OUTLINE &&
+        css`
+            border: 1px solid;
+            border-radius: ${theme.spacing(1)};
+            padding: ${theme.spacing(0, 1.5)};
+            height: ${theme.spacing(6)};
+        `}
+
+    ${({ isTextarea, theme }): SimpleInterpolation =>
+        isTextarea &&
+        css`
+            padding: ${theme.spacing(1.5)};
+            height: ${theme.spacing(16)};
+            resize: none;
+        `}
+
+    ${({ isDisabled, theme }): SimpleInterpolation =>
+        isDisabled &&
+        css`
+            color: ${theme.colorDisabled};
+        `}
+
+    ${({ hasError, isDisabled, isFocused, isHovered, isValid, theme }): SimpleInterpolation =>
+        css`
+            /* stylelint-disable indentation */
+            border-color: ${getBorderColor({
+                defaultColor: theme.colorPrimary,
+                hasError,
+                isDisabled,
+                isFocused,
+                isHovered,
+                isValid,
+                theme,
+            })};
+            /* stylelint-enable indentation */
+        `}
+`;
+
+TextField.defaultProps = {
+    theme: themeBasic,
+};

--- a/src/app/components/molecules/SelectionControl/SelectionControl.sc.ts
+++ b/src/app/components/molecules/SelectionControl/SelectionControl.sc.ts
@@ -156,8 +156,8 @@ export const FakeInput = styled.div<FakeInputProps>`
         type === SelectionControlType.CHECKBOX &&
         css`
             border-radius: ${theme.spacing(0.5)};
-            width: ${theme.spacing(size === SelectionControlSize.SMALL ? 2.25 : 3)};
-            height: ${theme.spacing(size === SelectionControlSize.SMALL ? 2.25 : 3)};
+            width: ${theme.spacing(size === SelectionControlSize.SMALL ? 2 : 3)};
+            height: ${theme.spacing(size === SelectionControlSize.SMALL ? 2 : 3)};
         `}
 
     ${({ size, theme, type }): SimpleInterpolation =>

--- a/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.stories.tsx
+++ b/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.stories.tsx
@@ -10,6 +10,7 @@ export const Configurable: FunctionComponent = () => {
 
     options.push(
         {
+            isDisabled: false,
             label: 'Girls',
             value: 'female',
         },
@@ -18,6 +19,7 @@ export const Configurable: FunctionComponent = () => {
             value: 'male',
         },
         {
+            isDisabled: true,
             label: 'Mixed',
             value: 'mixed',
         }

--- a/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.tsx
+++ b/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.tsx
@@ -105,13 +105,14 @@ export const SelectionControlGroup: FunctionComponent<SelectionControlGroupProps
                                 direction={direction}
                                 hasError={hasError || !isValidInputData}
                                 isChecked={selectedValue === option.value}
-                                isDisabled={isDisabled}
+                                isDisabled={isDisabled || option.isDisabled}
                                 // eslint-disable-next-line react/no-array-index-key
                                 key={index}
+                                label={option.label}
                                 name={groupName}
                                 onChange={onChangeCallback}
                                 type={SelectionControlType.RADIO}
-                                {...option}
+                                value={option.value}
                             />
                         </SelectionControlWrapper>
                     ))}

--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -207,7 +207,7 @@ interface IconWrapperProps {
 
 export const IconWrapper = styled.div<IconWrapperProps>`
     flex: 0 0 auto;
-    margin: 0 16px 0 0;
+    margin: ${({ theme }): string => theme.spacing(0.75, 2, 0, 0)};
     color: ${({ status, theme }): string => getStatusColor(status, theme)};
 
     span {

--- a/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { boolean, select, text } from '@storybook/addon-knobs';
-import { editableInformationCurrency, updateValuesOfCurrency } from './mockup/editableInformationCurrency';
 import { editableInformationData, updateValuesOfData } from './mockup/editableInformationData';
 import { EditableInformationData, ValueTypes } from './types';
 import { IconType, Locale, Status } from '../../../types';
@@ -10,6 +8,7 @@ import { DEFAULT_LOCALE } from '../../../../global/constants';
 import { DropdownMultiSelectOption } from '../DropdownMultiSelect';
 import { DropdownSelectOption } from '../DropdownSelect/DropdownSelect';
 import EditableInformation from './EditableInformation';
+import { editableInformationCurrency } from './mockup/editableInformationCurrency';
 import { editableInformationDataWithErrorMessages } from './mockup/editableInformationDataWithErrorMessages';
 
 export default { title: 'organisms/EditableInformation' };
@@ -24,7 +23,6 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
     isEditable = true,
     errors = undefined as unknown as string[],
     warnings = undefined as unknown as string[],
-    isCurrencyOnly = false,
     hasSaveAction = true
 ): JSX.Element => {
     const [updatedData, setUpdatedData] = useState<EditableInformationData<T, U>>(data);
@@ -43,9 +41,7 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
         setIsSaving(true);
         setIsEditing(isEditingMode);
 
-        setUpdatedData(
-            isCurrencyOnly ? updateValuesOfCurrency(updatedData, newData) : updateValuesOfData(updatedData, newData)
-        );
+        setUpdatedData(updateValuesOfData(updatedData, newData));
 
         // Show loading state for 5 seconds
         setTimeout(() => {
@@ -69,14 +65,8 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
         // eslint-disable-next-line no-console
         console.log('onChangeCallback', newData);
 
-        setUpdatedData(
-            isCurrencyOnly
-                ? updateValuesOfCurrency(updatedData, newData as { [key: string]: ValueTypes<T, U> })
-                : updateValuesOfData(updatedData, newData as { [key: string]: ValueTypes<T, U> })
-        );
+        setUpdatedData(updateValuesOfData(updatedData, newData as { [key: string]: ValueTypes<T, U> }));
     };
-
-    console.log('root - updatedData', updatedData);
 
     const onValidationCallback = (isValidData: boolean) => {
         // eslint-disable-next-line no-console
@@ -138,7 +128,7 @@ export const Configurable: FunctionComponent = () => BaseComponent(theData());
 export const ConfigurableEditingDefault: FunctionComponent = () => BaseComponent(theData(), true);
 
 export const ConfigurableEditingWithoutButtons: FunctionComponent = () =>
-    BaseComponent(theData(), true, false, true, [], [], false, false);
+    BaseComponent(theData(), true, false, true, [], [], false);
 
 export const ConfigurableWithConfirmationDialogs: FunctionComponent = () => BaseComponent(theData(), false, true);
 
@@ -160,7 +150,7 @@ export const ConfigurableWithWarningsAfterSaving: FunctionComponent = () =>
     BaseComponent(theData(), false, false, true, undefined, ['Warning number 1', 'Warning number 2']);
 
 export const ConfigurableCurrencyOnly: FunctionComponent = () =>
-    BaseComponent(theData(true), false, false, true, undefined, undefined, true);
+    BaseComponent(theData(true), false, false, true, undefined, undefined);
 
 export const ConfigurableCurrencyWithErrorsAfterSaving: FunctionComponent = () =>
     BaseComponent(theData(true), false, false, true, ['Error number 1', 'Error number 2']);

--- a/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
@@ -68,12 +68,15 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
     const onChangeCallback = (newData: unknown) => {
         // eslint-disable-next-line no-console
         console.log('onChangeCallback', newData);
+
+        setUpdatedData(
+            isCurrencyOnly
+                ? updateValuesOfCurrency(updatedData, newData as { [key: string]: ValueTypes<T, U> })
+                : updateValuesOfData(updatedData, newData as { [key: string]: ValueTypes<T, U> })
+        );
     };
 
-    const onRequestDataCallback = (currentData: unknown, isDataChanged: boolean) => {
-        // eslint-disable-next-line no-console
-        console.log('onRequestDataCallback -> isDataChanged, data', isDataChanged, currentData);
-    };
+    console.log('root - updatedData', updatedData);
 
     const onValidationCallback = (isValidData: boolean) => {
         // eslint-disable-next-line no-console
@@ -107,7 +110,6 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
             onCancel={onCancelCallback}
             onChange={onChangeCallback}
             onEdit={isEditable ? action('onEdit') : undefined}
-            onRequestData={onRequestDataCallback}
             onSave={hasSaveAction && isEditable ? onSaveCallback : undefined}
             onValidation={isEditable ? onValidationCallback : undefined}
             saveConfirmDialog={

--- a/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
@@ -35,9 +35,9 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
         setIsEditing((saveErrors && saveErrors.length !== 0) || isEditingMode);
     }, [isEditingMode, saveErrors]);
 
-    const onSaveCallback = (newData: { [key: string]: ValueTypes<T, U> }, isDataChanged?: boolean): void => {
+    const onSaveCallback = (newData: { [key: string]: ValueTypes<T, U> }): void => {
         // eslint-disable-next-line no-console
-        console.log('onSaveCallback -> isDataChanged : ', isDataChanged);
+        console.log('[onSaveCallback]] ', newData);
         setIsSaving(true);
         setIsEditing(isEditingMode);
 

--- a/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.stories.tsx
@@ -70,6 +70,11 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
         console.log('onChangeCallback', newData);
     };
 
+    const onRequestDataCallback = (currentData: unknown, isDataChanged: boolean) => {
+        // eslint-disable-next-line no-console
+        console.log('onRequestDataCallback -> isDataChanged, data', isDataChanged, currentData);
+    };
+
     const onValidationCallback = (isValidData: boolean) => {
         // eslint-disable-next-line no-console
         console.log('onValidationCallback', isValidData);
@@ -102,6 +107,7 @@ const BaseComponent = <T extends DropdownSelectOption, U extends DropdownMultiSe
             onCancel={onCancelCallback}
             onChange={onChangeCallback}
             onEdit={isEditable ? action('onEdit') : undefined}
+            onRequestData={onRequestDataCallback}
             onSave={hasSaveAction && isEditable ? onSaveCallback : undefined}
             onValidation={isEditable ? onValidationCallback : undefined}
             saveConfirmDialog={

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -45,6 +45,7 @@ export interface EditableInformationProps<T extends DropdownOption, U extends Dr
     onCancel?: () => void;
     onChange?: (data: unknown, isDataChanged: boolean) => void;
     onEdit?: () => void;
+    onRequestData?: (data: unknown, isDataChanged: boolean) => void;
     onSave?: (data: { [key: string]: ValueTypes<T, U> }, isDataChanged: boolean) => void;
     onValidation?: (isValidData: boolean) => void;
     saveConfirmDialog?: ConfirmDialog;
@@ -76,6 +77,7 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     onCancel,
     onChange,
     onEdit,
+    onRequestData,
     onSave,
     onValidation,
     saveConfirmDialog,
@@ -202,6 +204,13 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
             setIsValidInputData(isValidEditableInput(data, updatedValues, localeValue));
         }
     }, [data, updatedValues]);
+
+    // We might want to know what the data looks like at any given moment
+    useEffect(() => {
+        if (onRequestData) {
+            onRequestData(updatedValues, !areEqualObjects(originalValues, updatedValues));
+        }
+    }, [originalValues, updatedValues]);
 
     // When validation of the input data is changed call onValidation to perform action needed outside the component
     useEffect(() => {

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -137,15 +137,34 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     }, [originalValues, onCancel]);
 
     const onChangeCallback = useCallback(
-        (name: string, value: ValueTypes<T, U>) => {
-            const newValues = {
+        (name: string, value: ValueTypes<T, U>, callExternOnChange = true, isCurrency = false) => {
+            let newValues = {
                 ...updatedValues,
-                [name]: value,
             };
+
+            // if it is a temporary value of currency add temp property in values for validation purposes
+            if (isCurrency && !callExternOnChange) {
+                newValues = {
+                    ...newValues,
+                    [`${name}_currency_temp_value`]: value,
+                };
+            }
+
+            if (isCurrency && callExternOnChange) {
+                // definitive value of currency, delete the temp one for correct validation
+                delete newValues[`${name}_currency_temp_value`];
+            }
+
+            if (!isCurrency || callExternOnChange) {
+                newValues = {
+                    ...newValues,
+                    [name]: value,
+                };
+            }
 
             setUpdatedValues(newValues);
 
-            if (onChange) {
+            if (callExternOnChange && onChange) {
                 onChange(newValues, !areEqualObjects(newValues, originalValues));
             }
         },

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -196,7 +196,7 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
         setIsEditable(isEditableData(data));
     }, [data]);
 
-    // When updated values are changed do validation
+    // When updated values are changed due to validation
     useEffect(() => {
         if (!isEmpty(data) && !isEmpty(updatedValues)) {
             setIsValidInputData(isValidEditableInput(data, updatedValues, localeValue));

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -12,7 +12,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { areEqualObjects } from '../../../utils/functions/objectFunctions';
 import CardStatus from '../../molecules/CardStatus/CardStatus';
 import { ConfirmDialog } from '../EditablePanel';
-import { convertToLocaleValue } from '../../../utils/functions/financialFunctions';
 import { DEFAULT_LOCALE } from '../../../../global/constants';
 import { DropdownMultiSelectOption } from '../DropdownMultiSelect';
 import { DropdownOption } from '../../molecules/Dropdown';
@@ -138,20 +137,15 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     }, [originalValues, onCancel]);
 
     const onChangeCallback = useCallback(
-        (name: string, value: ValueTypes<T, U>, callExternOnChange = true, isCurrency = false) => {
-            let newValues = {
+        (name: string, value: ValueTypes<T, U>) => {
+            const newValues = {
                 ...updatedValues,
                 [name]: value,
             };
 
             setUpdatedValues(newValues);
 
-            if (callExternOnChange && onChange) {
-                newValues = {
-                    ...updatedValues,
-                    [name]: isCurrency && value ? convertToLocaleValue(value as string, localeValue) : value,
-                };
-
+            if (onChange) {
                 onChange(newValues, !areEqualObjects(newValues, originalValues));
             }
         },
@@ -225,7 +219,7 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
                 }, {})
             );
 
-            const values = generateValuesArray(data, localeValue);
+            const values = generateValuesArray(data);
 
             // initialize 2 arrays of Values
             setOriginalValues(values);

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -45,7 +45,6 @@ export interface EditableInformationProps<T extends DropdownOption, U extends Dr
     onCancel?: () => void;
     onChange?: (data: unknown, isDataChanged: boolean) => void;
     onEdit?: () => void;
-    onRequestData?: (data: unknown, isDataChanged: boolean) => void;
     onSave?: (data: { [key: string]: ValueTypes<T, U> }, isDataChanged: boolean) => void;
     onValidation?: (isValidData: boolean) => void;
     saveConfirmDialog?: ConfirmDialog;
@@ -77,7 +76,6 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     onCancel,
     onChange,
     onEdit,
-    onRequestData,
     onSave,
     onValidation,
     saveConfirmDialog,
@@ -204,13 +202,6 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
             setIsValidInputData(isValidEditableInput(data, updatedValues, localeValue));
         }
     }, [data, updatedValues]);
-
-    // We might want to know what the data looks like at any given moment
-    useEffect(() => {
-        if (onRequestData) {
-            onRequestData(updatedValues, !areEqualObjects(originalValues, updatedValues));
-        }
-    }, [originalValues, updatedValues]);
 
     // When validation of the input data is changed call onValidation to perform action needed outside the component
     useEffect(() => {

--- a/src/app/components/organisms/EditableInformation/EditableInformation.tsx
+++ b/src/app/components/organisms/EditableInformation/EditableInformation.tsx
@@ -138,7 +138,7 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
     }, [originalValues, onCancel]);
 
     const onChangeCallback = useCallback(
-        (name: string, value: ValueTypes<T, U>, isCurrency = false) => {
+        (name: string, value: ValueTypes<T, U>, callExternOnChange = true, isCurrency = false) => {
             let newValues = {
                 ...updatedValues,
                 [name]: value,
@@ -146,12 +146,12 @@ export const EditableInformation = <T extends DropdownOption, U extends Dropdown
 
             setUpdatedValues(newValues);
 
-            newValues = {
-                ...updatedValues,
-                [name]: isCurrency && value ? convertToLocaleValue(value as string, localeValue) : value,
-            };
+            if (callExternOnChange && onChange) {
+                newValues = {
+                    ...updatedValues,
+                    [name]: isCurrency && value ? convertToLocaleValue(value as string, localeValue) : value,
+                };
 
-            if (onChange) {
                 onChange(newValues, !areEqualObjects(newValues, originalValues));
             }
         },

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -25,7 +25,7 @@ export interface EditableDataProps<T extends DropdownOption, U extends DropdownM
     isBeingEdited: boolean;
     locale?: Locale;
     localeCurrency?: Locale;
-    onChange: (name: string, value: ValueTypes<T, U>, isCurrency?: boolean, locale?: Locale) => void;
+    onChange: (name: string, value: ValueTypes<T, U>, callExternOnChange?: boolean, isCurrency?: boolean) => void;
     onDatePickerFocusChange: (name: string, focused: boolean) => void;
     onDropdownChange: (option: T, name: string, propertyNameOfId?: string) => void;
     values: {
@@ -252,12 +252,14 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             min={dataInstance.min}
                             name={name}
                             onBlur={(event): void => {
+                                onChange(event.currentTarget.name, event.currentTarget.value, true, true);
+
                                 if (dataInstance.onBlur) {
                                     dataInstance.onBlur(event);
                                 }
                             }}
                             onChange={({ currentTarget }): void => {
-                                onChange(currentTarget.name, currentTarget.value, true, locale);
+                                onChange(currentTarget.name, currentTarget.value, false, true);
                             }}
                             onFocus={(event): void => {
                                 if (dataInstance.onFocus) {

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -252,14 +252,12 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             min={dataInstance.min}
                             name={name}
                             onBlur={(event): void => {
-                                onChange(event.currentTarget.name, event.currentTarget.value, true, true);
-
                                 if (dataInstance.onBlur) {
                                     dataInstance.onBlur(event);
                                 }
                             }}
                             onChange={({ currentTarget }): void => {
-                                onChange(currentTarget.name, currentTarget.value, false, true);
+                                onChange(currentTarget.name, currentTarget.value);
                             }}
                             onFocus={(event): void => {
                                 if (dataInstance.onFocus) {

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -252,12 +252,14 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             min={dataInstance.min}
                             name={name}
                             onBlur={(event): void => {
+                                onChange(event.currentTarget.name, event.currentTarget.value, true, true);
+
                                 if (dataInstance.onBlur) {
                                     dataInstance.onBlur(event);
                                 }
                             }}
                             onChange={({ currentTarget }): void => {
-                                onChange(currentTarget.name, currentTarget.value);
+                                onChange(currentTarget.name, currentTarget.value, false, true);
                             }}
                             onFocus={(event): void => {
                                 if (dataInstance.onFocus) {

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -375,25 +375,6 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                 };
             }
 
-            if (dataInstance.component === EditableDataComponent.TEXTAREA_READONLY) {
-                return {
-                    label,
-                    value: (
-                        <Input
-                            errorMessage={dataInstance.errorMessage}
-                            hasError={hasInputError || dataInstance.hasError}
-                            ignoreOutlineVariant
-                            isDisabled={isDisabled}
-                            isTextarea
-                            label={dataInstance.placeholder}
-                            locale={locale}
-                            name={name}
-                            value={values[name] as string | undefined}
-                        />
-                    ),
-                };
-            }
-
             if (dataInstance.component === EditableDataComponent.TIMEPICKER) {
                 return {
                     label,

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
@@ -11,6 +11,7 @@ export const editableInformationCurrency = <
 
     result.push({
         component: EditableDataComponent.INPUTCURRENCY,
+        errorMessage: 'Value should be between 1 and 10 euros only',
         isDisabled: false,
         isEditable: true,
         isRequired: true,
@@ -23,9 +24,9 @@ export const editableInformationCurrency = <
 
     result.push({
         component: EditableDataComponent.INPUTCURRENCY,
+        errorMessage: 'Value should be between 0 and 10 euros only',
         isDisabled: false,
         isEditable: true,
-        isRequired: true,
         label: 'EditableCurrency',
         max: 10,
         min: 0,
@@ -35,6 +36,7 @@ export const editableInformationCurrency = <
 
     result.push({
         component: EditableDataComponent.INPUTCURRENCY,
+        errorMessage: 'This field is required',
         isDisabled: false,
         isEditable: true,
         isRequired: true,
@@ -45,6 +47,7 @@ export const editableInformationCurrency = <
 
     result.push({
         component: EditableDataComponent.INPUTCURRENCY,
+        errorMessage: 'This field is required',
         isDisabled: false,
         isEditable: true,
         isRequired: true,
@@ -55,6 +58,7 @@ export const editableInformationCurrency = <
 
     result.push({
         component: EditableDataComponent.INPUTCURRENCY,
+        errorMessage: 'This field is required',
         isDisabled: false,
         isEditable: true,
         isRequired: true,

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
@@ -7,7 +7,6 @@ import {
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import { EditableDataComponent } from '../../../../types';
-import React from 'react';
 
 export const updateValuesOfCurrency = <T extends DropdownSelectOption, U extends DropdownMultiSelectOption>(
     data: EditableInformationData<T, U>,
@@ -33,33 +32,15 @@ export const editableInformationCurrency = <
 >(): EditableInformationData<T, U> => {
     const result: EditableInformationData<T, U> = [];
 
-    const onBlurCallback = (event: React.FocusEvent<HTMLInputElement>): void => {
-        // eslint-disable-next-line no-console
-        console.log('onBlurCallback', event);
-    };
-
-    const onFocusCallback = (event: React.FocusEvent<HTMLInputElement>): void => {
-        // eslint-disable-next-line no-console
-        console.log('onFocusCallback', event);
-    };
-
-    const onKeyDownCallback = (event: React.KeyboardEvent<HTMLInputElement>): void => {
-        // eslint-disable-next-line no-console
-        console.log('onKeyDownCallback', event);
-    };
-
     result.push({
         component: EditableDataComponent.INPUTCURRENCY,
         isDisabled: false,
         isEditable: true,
         isRequired: true,
-        label: 'Currency',
+        label: 'EditableCurrencyRequiredDefaultZero',
         max: 10,
         min: 1,
         name: 'EditableCurrencyRequiredDefaultZero',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
         value: '0',
     } as EditableInputCurrencyDataProps);
 
@@ -68,13 +49,10 @@ export const editableInformationCurrency = <
         isDisabled: false,
         isEditable: true,
         isRequired: true,
-        label: 'Currency',
+        label: 'EditableCurrency',
         max: 10,
         min: 0,
         name: 'EditableCurrency',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
         value: '0.51',
     } as EditableInputCurrencyDataProps);
 
@@ -83,11 +61,8 @@ export const editableInformationCurrency = <
         isDisabled: false,
         isEditable: true,
         isRequired: true,
-        label: 'Currency2',
+        label: 'EditableCurrency2',
         name: 'EditableCurrency2',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
         value: '123.51',
     } as EditableInputCurrencyDataProps);
 
@@ -96,11 +71,8 @@ export const editableInformationCurrency = <
         isDisabled: false,
         isEditable: true,
         isRequired: true,
-        label: 'Currency (comma)',
+        label: 'EditableCurrencyComma',
         name: 'EditableCurrencyComma',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
         value: '451,123.87',
     } as EditableInputCurrencyDataProps);
 
@@ -111,9 +83,6 @@ export const editableInformationCurrency = <
         isRequired: true,
         label: 'NegativeCurrency',
         name: 'NegativeCurrency',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
         value: '-108',
     } as EditableInputCurrencyDataProps);
 

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
@@ -1,30 +1,7 @@
-import {
-    EditableInformationData,
-    EditableInformationDataType,
-    EditableInputCurrencyDataProps,
-    ValueTypes,
-} from '../types';
+import { EditableInformationData, EditableInputCurrencyDataProps } from '../types';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import { EditableDataComponent } from '../../../../types';
-
-export const updateValuesOfCurrency = <T extends DropdownSelectOption, U extends DropdownMultiSelectOption>(
-    data: EditableInformationData<T, U>,
-    values: { [key: string]: ValueTypes<T, U> }
-): EditableInformationData<T, U> => {
-    const newData = data.map((element: EditableInformationDataType<T, U>) => {
-        if ('name' in element && element.name in values) {
-            return {
-                ...element,
-                value: values[element.name],
-            };
-        }
-
-        return element;
-    });
-
-    return newData as EditableInformationData<T, U>;
-};
 
 export const editableInformationCurrency = <
     T extends DropdownSelectOption,

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationCurrency.tsx
@@ -55,6 +55,21 @@ export const editableInformationCurrency = <
         isRequired: true,
         label: 'Currency',
         max: 10,
+        min: 1,
+        name: 'EditableCurrencyRequiredDefaultZero',
+        onBlur: onBlurCallback,
+        onFocus: onFocusCallback,
+        onKeyDown: onKeyDownCallback,
+        value: '0',
+    } as EditableInputCurrencyDataProps);
+
+    result.push({
+        component: EditableDataComponent.INPUTCURRENCY,
+        isDisabled: false,
+        isEditable: true,
+        isRequired: true,
+        label: 'Currency',
+        max: 10,
         min: 0,
         name: 'EditableCurrency',
         onBlur: onBlurCallback,

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -22,7 +22,6 @@ import { Fruit, fruits } from './fruits';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import moment from 'moment';
-import React from 'react';
 
 export const updateValuesOfData = <T extends DropdownSelectOption, U extends DropdownMultiSelectOption>(
     data: EditableInformationData<T, U>,
@@ -44,21 +43,6 @@ export const updateValuesOfData = <T extends DropdownSelectOption, U extends Dro
 
 export const editableInformationData = <T extends Fruit, U extends Fruit>(): EditableInformationData<T, U> => {
     const result: EditableInformationData<T, U> = [];
-
-    const onBlurCallback = (event: React.FocusEvent<HTMLInputElement>): void => {
-        // eslint-disable-next-line no-console
-        console.log('onBlurCallback', event);
-    };
-
-    const onFocusCallback = (event: React.FocusEvent<HTMLInputElement>): void => {
-        // eslint-disable-next-line no-console
-        console.log('onFocusCallback', event);
-    };
-
-    const onKeyDownCallback = (event: React.KeyboardEvent<HTMLInputElement>): void => {
-        // eslint-disable-next-line no-console
-        console.log('onKeyDownCallback', event);
-    };
 
     result.push({
         component: EditableDataComponent.DATEPICKER,
@@ -104,9 +88,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         label: 'Number',
         min: 0,
         name: 'Number',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: 0,
     } as EditableInputNumberDataProps);
 
@@ -118,9 +100,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         label: 'BadNumber',
         min: 0,
         name: 'BadNumber',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: -1,
     } as EditableInputNumberDataProps);
 
@@ -131,9 +111,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         isRequired: true,
         label: 'Input (null value)',
         name: 'InputNull',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: null,
     } as EditableInputDataProps);
 
@@ -145,9 +123,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         label: 'Input (not editable)',
         maxLength: 20,
         name: 'Input',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: 'Banana',
     } as EditableInputDataProps);
 
@@ -178,9 +154,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         isEditable: true,
         label: 'Textarea',
         name: 'EditableTextArea',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: 'text here',
     } as EditableTextareaDataProps);
 
@@ -188,14 +162,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         component: EditableDataComponent.TEXTAREA_READONLY,
         label: 'Textarea ReactNode',
         name: 'NonEditableTextAreaReactNode',
-        value: (
-            <span
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{
-                    __html: 'Bondssport:<br/>- Voetbal - Algemeen/Veld<br/>Verenigingssport:<br/>- Balgooien - Maandag/ACTIE<br/><br/>Er is/zijn één of meer verenigingssporten vastgelegd.<br/><br/>Voormalige of huidige vereniging:<br/>- Spero (BBKT07Z)<br/>- Relatiecode: HDHDHDGU (Niet gevonden)<br/><br/>Aangevraagd lidsoort: Bondslid<br/><br/>Aangevraagd lidsoort: Verenigingslid',
-                }}
-            />
-        ),
+        value: 'Bondssport:<br/>- Voetbal - Algemeen/Veld<br/>Verenigingssport:<br/>- Balgooien - Maandag/ACTIE<br/><br/>Er is/zijn één of meer verenigingssporten vastgelegd.<br/><br/>Voormalige of huidige vereniging:<br/>- Spero (BBKT07Z)<br/>- Relatiecode: HDHDHDGU (Niet gevonden)<br/><br/>Aangevraagd lidsoort: Bondslid<br/><br/>Aangevraagd lidsoort: Verenigingslid',
     } as EditableTextareaReadOnlyDataProps);
 
     result.push({
@@ -205,9 +172,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         isRequired: true,
         label: 'Currency',
         name: 'EditableCurrency',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: '0.51',
     } as EditableInputCurrencyDataProps);
 
@@ -218,9 +183,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         isRequired: true,
         label: 'Currency2',
         name: 'EditableCurrency2',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: '123.51',
     } as EditableInputCurrencyDataProps);
 
@@ -231,9 +194,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         isRequired: true,
         label: 'Currency (comma)',
         name: 'EditableCurrencyComma',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: '451,123.87',
     } as EditableInputCurrencyDataProps);
 
@@ -244,9 +205,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         isRequired: true,
         label: 'NegativeCurrency',
         name: 'NegativeCurrency',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: '-108',
     } as EditableInputCurrencyDataProps);
 
@@ -295,9 +254,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         max: 10,
         min: 0,
         name: 'EditableNumber',
-        onBlur: onBlurCallback,
-        onFocus: onFocusCallback,
-        onKeyDown: onKeyDownCallback,
+
         value: 5,
     } as EditableInputNumberDataProps);
 

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -71,6 +71,15 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
     } as DatePickerDataProps);
 
     result.push({
+        component: EditableDataComponent.DATEPICKER,
+        isEditable: true,
+        isVisibleOnlyOnEdit: true,
+        label: 'NullDate',
+        name: 'NullDate',
+        value: null,
+    } as DatePickerDataProps);
+
+    result.push({
         component: EditableDataComponent.TIMEPICKER,
         isEditable: false,
         label: 'Time',

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -22,6 +22,7 @@ import { Fruit, fruits } from './fruits';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import moment from 'moment';
+import React from 'react';
 
 export const updateValuesOfData = <T extends DropdownSelectOption, U extends DropdownMultiSelectOption>(
     data: EditableInformationData<T, U>,
@@ -162,7 +163,14 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         component: EditableDataComponent.TEXTAREA_READONLY,
         label: 'Textarea ReactNode',
         name: 'NonEditableTextAreaReactNode',
-        value: 'Bondssport:<br/>- Voetbal - Algemeen/Veld<br/>Verenigingssport:<br/>- Balgooien - Maandag/ACTIE<br/><br/>Er is/zijn één of meer verenigingssporten vastgelegd.<br/><br/>Voormalige of huidige vereniging:<br/>- Spero (BBKT07Z)<br/>- Relatiecode: HDHDHDGU (Niet gevonden)<br/><br/>Aangevraagd lidsoort: Bondslid<br/><br/>Aangevraagd lidsoort: Verenigingslid',
+        value: (
+            <span
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                    __html: 'Bondssport:<br/>- Voetbal - Algemeen/Veld<br/>Verenigingssport:<br/>- Balgooien - Maandag/ACTIE<br/><br/>Er is/zijn één of meer verenigingssporten vastgelegd.<br/><br/>Voormalige of huidige vereniging:<br/>- Spero (BBKT07Z)<br/>- Relatiecode: HDHDHDGU (Niet gevonden)<br/><br/>Aangevraagd lidsoort: Bondslid<br/><br/>Aangevraagd lidsoort: Verenigingslid',
+                }}
+            />
+        ) as unknown as string,
     } as EditableTextareaReadOnlyDataProps);
 
     result.push({

--- a/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
+++ b/src/app/components/organisms/EditableInformation/mockup/editableInformationData.tsx
@@ -22,7 +22,6 @@ import { Fruit, fruits } from './fruits';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import moment from 'moment';
-import React from 'react';
 
 export const updateValuesOfData = <T extends DropdownSelectOption, U extends DropdownMultiSelectOption>(
     data: EditableInformationData<T, U>,
@@ -163,14 +162,7 @@ export const editableInformationData = <T extends Fruit, U extends Fruit>(): Edi
         component: EditableDataComponent.TEXTAREA_READONLY,
         label: 'Textarea ReactNode',
         name: 'NonEditableTextAreaReactNode',
-        value: (
-            <span
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{
-                    __html: 'Bondssport:<br/>- Voetbal - Algemeen/Veld<br/>Verenigingssport:<br/>- Balgooien - Maandag/ACTIE<br/><br/>Er is/zijn één of meer verenigingssporten vastgelegd.<br/><br/>Voormalige of huidige vereniging:<br/>- Spero (BBKT07Z)<br/>- Relatiecode: HDHDHDGU (Niet gevonden)<br/><br/>Aangevraagd lidsoort: Bondslid<br/><br/>Aangevraagd lidsoort: Verenigingslid',
-                }}
-            />
-        ) as unknown as string,
+        value: 'Bondssport:<br/>- Voetbal - Algemeen/Veld<br/>Verenigingssport:<br/>- Balgooien - Maandag/ACTIE<br/><br/>Er is/zijn één of meer verenigingssporten vastgelegd.<br/><br/>Voormalige of huidige vereniging:<br/>- Spero (BBKT07Z)<br/>- Relatiecode: HDHDHDGU (Niet gevonden)<br/><br/>Aangevraagd lidsoort: Bondslid<br/><br/>Aangevraagd lidsoort: Verenigingslid',
     } as EditableTextareaReadOnlyDataProps);
 
     result.push({

--- a/src/app/components/organisms/EditableInformation/types.ts
+++ b/src/app/components/organisms/EditableInformation/types.ts
@@ -152,7 +152,7 @@ export interface TextareaDataProps extends BaseDataProps {
 
 export interface TextareaReadOnlyDataProps extends BaseDataProps {
     component: EditableDataComponent.TEXTAREA_READONLY;
-    value: InputProps['value'] | ReactNode;
+    value: InputProps['value'];
 }
 
 export interface EditableTextareaDataProps extends TextareaDataProps {

--- a/src/app/components/organisms/EditableInformation/utils/generateValuesArray.ts
+++ b/src/app/components/organisms/EditableInformation/utils/generateValuesArray.ts
@@ -1,5 +1,3 @@
-import { toCents, toMoneyValue } from '../../../../utils/functions/financialFunctions';
-import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import { EditableDataComponent } from '../../../../types';
@@ -7,8 +5,7 @@ import { EditableDataProps } from '../editableData/editableData';
 import { EditableInformationData } from '../types';
 
 export const generateValuesArray = <T extends DropdownSelectOption, U extends DropdownMultiSelectOption>(
-    data: EditableInformationData<T, U>,
-    locale = DEFAULT_LOCALE
+    data: EditableInformationData<T, U>
 ): EditableDataProps<T, U>['values'] =>
     data.reduce((accumulator, dataInstance) => {
         if ('name' in dataInstance) {
@@ -36,12 +33,12 @@ export const generateValuesArray = <T extends DropdownSelectOption, U extends Dr
                 };
             }
 
-            if (dataInstance.component === EditableDataComponent.INPUTCURRENCY) {
-                return {
-                    ...accumulator,
-                    [dataInstance.name]: toMoneyValue(toCents(dataInstance.value || ''), locale, true).toString(),
-                };
-            }
+            // if (dataInstance.component === EditableDataComponent.INPUTCURRENCY) {
+            //     return {
+            //         ...accumulator,
+            //         [dataInstance.name]: toMoneyValue(toCents(dataInstance.value || ''), locale, true).toString(),
+            //     };
+            // }
 
             return {
                 ...accumulator,

--- a/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
+++ b/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
@@ -7,6 +7,7 @@ import {
     EditableDropdownSelectDataProps,
     EditableInformationData,
     EditableInformationDataType,
+    EditableInputCurrencyDataProps,
     EditableInputDataProps,
     EditableInputNumberDataProps,
     ValueTypes,
@@ -100,6 +101,20 @@ export const isValidEditableInput = <T extends DropdownSelectOption, U extends D
     locale: Locale
 ): boolean =>
     data.every((item): boolean => {
+        if (item.component === EditableDataComponent.INPUTCURRENCY) {
+            const tempMoneyValueName = `${(item as EditableInputCurrencyDataProps).name}_currency_temp_value`;
+
+            if (tempMoneyValueName in values) {
+                return isValidInputNumber(
+                    values[tempMoneyValueName]?.toString() || null,
+                    locale,
+                    item.isRequired || false,
+                    (item as EditableInputCurrencyDataProps).min,
+                    (item as EditableInputCurrencyDataProps).max
+                );
+            }
+        }
+
         switch (item.component) {
             /* eslint-disable padding-line-between-statements */
             case EditableDataComponent.DROPDOWN:

--- a/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
+++ b/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
@@ -7,27 +7,25 @@ import {
     EditableDropdownSelectDataProps,
     EditableInformationData,
     EditableInformationDataType,
-    EditableInputCurrencyDataProps,
     EditableInputDataProps,
     EditableInputNumberDataProps,
     ValueTypes,
 } from '../types';
 import { EditableDataComponent, InputType, Locale, Status } from '../../../../types';
-import { formatMoney, toCents, toMoneyValue } from '../../../../utils/functions/financialFunctions';
 import {
     isEmpty,
-    isValidInputCurrency,
     isValidInputEmail,
     isValidInputNumber,
     isValidInputTelephone,
     isValidInputText,
 } from '../../../../utils/functions/validateFunctions';
-import React, { ReactNode } from 'react';
+import { convertToLocaleValue } from '../../../../utils/functions/financialFunctions';
 import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import { getSelectedText } from '../../../../utils/functions/arrayObjectFunctions';
 import moment from 'moment';
+import { ReactNode } from 'react';
 
 export const getStatus = (hasError: boolean, isLoading?: boolean, isDisabled?: boolean): Status => {
     if (hasError) {
@@ -67,23 +65,8 @@ export const getValueOfEditableDataComponent = <T extends DropdownSelectOption, 
         return value.format(dateFormat);
     }
 
-    if (component === EditableDataComponent.TEXTAREA_READONLY && value) {
-        return (
-            <span
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{
-                    __html: (value as string) || '',
-                }}
-            />
-        );
-    }
-
     if (component === EditableDataComponent.INPUTCURRENCY && value) {
-        // Let localeCurrency prevail over locale when presnt
-        return formatMoney(
-            toMoneyValue(toCents(value.toString()), localeCurrency || locale, true),
-            localeCurrency || locale
-        );
+        return convertToLocaleValue((value as string) || '', localeCurrency || locale);
     }
 
     if (component === EditableDataComponent.SCOREPICKER && Array.isArray(value)) {
@@ -161,14 +144,9 @@ export const isValidEditableInput = <T extends DropdownSelectOption, U extends D
                     (item as EditableInputDataProps).maxLength
                 );
 
-            case EditableDataComponent.INPUTCURRENCY:
-                return isValidInputCurrency(
-                    values[(item as EditableInputCurrencyDataProps).name]?.toString() || '',
-                    locale,
-                    item.isRequired || false
-                );
-
+            /* eslint-disable padding-line-between-statements */
             case EditableDataComponent.INPUTNUMBER:
+            case EditableDataComponent.INPUTCURRENCY:
                 return isValidInputNumber(
                     values[(item as EditableInputNumberDataProps).name]?.toString() || null,
                     locale,

--- a/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
+++ b/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
@@ -67,7 +67,7 @@ export const getValueOfEditableDataComponent = <T extends DropdownSelectOption, 
         return value.format(dateFormat);
     }
 
-    if (component === EditableDataComponent.INPUTCURRENCY && value) {
+    if (component === EditableDataComponent.TEXTAREA_READONLY && value) {
         return (
             <span
                 // eslint-disable-next-line react/no-danger

--- a/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
+++ b/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
@@ -22,12 +22,12 @@ import {
     isValidInputTelephone,
     isValidInputText,
 } from '../../../../utils/functions/validateFunctions';
+import React, { ReactNode } from 'react';
 import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import { getSelectedText } from '../../../../utils/functions/arrayObjectFunctions';
 import moment from 'moment';
-import { ReactNode } from 'react';
 
 export const getStatus = (hasError: boolean, isLoading?: boolean, isDisabled?: boolean): Status => {
     if (hasError) {
@@ -65,6 +65,17 @@ export const getValueOfEditableDataComponent = <T extends DropdownSelectOption, 
 
     if (component === EditableDataComponent.DATEPICKER && moment.isMoment(value)) {
         return value.format(dateFormat);
+    }
+
+    if (component === EditableDataComponent.INPUTCURRENCY && value) {
+        return (
+            <span
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                    __html: (value as string) || '',
+                }}
+            />
+        );
     }
 
     if (component === EditableDataComponent.INPUTCURRENCY && value) {

--- a/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
+++ b/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
@@ -20,13 +20,13 @@ import {
     isValidInputTelephone,
     isValidInputText,
 } from '../../../../utils/functions/validateFunctions';
+import React, { ReactNode } from 'react';
 import { convertToLocaleValue } from '../../../../utils/functions/financialFunctions';
 import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import { DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { DropdownSelectOption } from '../../DropdownSelect/DropdownSelect';
 import { getSelectedText } from '../../../../utils/functions/arrayObjectFunctions';
 import moment from 'moment';
-import { ReactNode } from 'react';
 
 export const getStatus = (hasError: boolean, isLoading?: boolean, isDisabled?: boolean): Status => {
     if (hasError) {
@@ -76,6 +76,17 @@ export const getValueOfEditableDataComponent = <T extends DropdownSelectOption, 
 
     if (component === EditableDataComponent.TIMEPICKER && Array.isArray(value)) {
         return value[0] && value[1] ? `${value[0] as string}:${value[1] as string}` : '-';
+    }
+
+    if (component === EditableDataComponent.TEXTAREA_READONLY && value) {
+        return (
+            <span
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                    __html: (value as string) || '',
+                }}
+            />
+        );
     }
 
     return textValue || value;

--- a/src/app/components/organisms/InputCurrency/InputCurrency.stories.tsx
+++ b/src/app/components/organisms/InputCurrency/InputCurrency.stories.tsx
@@ -7,7 +7,7 @@ import InputCurrency from './InputCurrency';
 export default { title: 'organisms/InputCurrency' };
 
 export const Configurable: FunctionComponent = () => {
-    const [value, setValue] = useState('');
+    const [value, setValue] = useState('0.51');
 
     return (
         <InputCurrency

--- a/src/app/components/organisms/InputCurrency/InputCurrency.tsx
+++ b/src/app/components/organisms/InputCurrency/InputCurrency.tsx
@@ -52,6 +52,7 @@ export const InputCurrency: FunctionComponent<InputCurrencyProps> = ({
         hasError={hasError}
         hasNegativeAmountColor={hasNegativeAmountColor}
         isDisabled={isDisabled}
+        isOnChangeRequired={false}
         isRequired={isRequired}
         isValid={isValid}
         label={label}

--- a/src/app/components/organisms/Modal/Modal.stories.tsx
+++ b/src/app/components/organisms/Modal/Modal.stories.tsx
@@ -5,8 +5,10 @@ import React, { FunctionComponent, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import Button from '../../molecules/Button/Button';
 import ButtonIcon from '../../molecules/ButtonIcon/ButtonIcon';
+import { EditableInformation } from '../EditableInformation/EditableInformation';
+import { editableInformationData } from '../EditableInformation/mockup/editableInformationData';
 import Modal from './Modal';
-import { SingleDatePicker } from '../DatePicker';
+import { SingleDatePicker } from '../DatePicker/SingleDatePicker/SingleDatePicker';
 
 export default { title: 'organisms/Modal' };
 
@@ -61,31 +63,38 @@ export const ConfigurableModal: FunctionComponent = () => {
                 transitionDuration={number('Transition duration', 500)}
                 transitionEasing={select('Transition type', Easing, Easing.EASE)}
             >
-                <>
-                    {text('Body', 'Some body text')}
-                    <div
-                        className="Parent"
-                        ref={setWrapperElementRef}
-                        style={{
-                            marginLeft: 'auto',
-                            width: '200px',
+                <div
+                    className="Parent"
+                    ref={setWrapperElementRef}
+                    style={{
+                        marginLeft: 'auto',
+                        width: '100%',
+                    }}
+                >
+                    <SingleDatePicker
+                        date={date}
+                        id="datepicker"
+                        isFocused={isFocused}
+                        onDateChange={(newDate): void => {
+                            setDate(newDate);
                         }}
-                    >
-                        <SingleDatePicker
-                            date={date}
-                            id="datepicker"
-                            isFocused={isFocused}
-                            onDateChange={(newDate): void => {
-                                setDate(newDate);
-                            }}
-                            onFocusChange={({ focused }): void => {
-                                setIsFocused(Boolean(focused));
-                            }}
-                            parentContainer={wrapperElementRef || undefined}
-                            placeholder={'Selecteer je datum'}
-                        />
-                    </div>
-                </>
+                        onFocusChange={({ focused }): void => {
+                            setIsFocused(Boolean(focused));
+                        }}
+                        parentContainer={wrapperElementRef || undefined}
+                        placeholder={'Selecteer je datum'}
+                    />
+                    <EditableInformation
+                        amountOfColumns={select('Columns', [1, 2, 3], 2)}
+                        data={editableInformationData()}
+                        iconType={select('Icon Type', IconType, IconType.CALENDAR)}
+                        isButtonDisabled={boolean('Is button disabled', false)}
+                        isDisabled={boolean('Is disabled', false)}
+                        isEditing
+                        isLoading={boolean('Is loading', false)}
+                        title={text('Title', 'Information')}
+                    />
+                </div>
             </Modal>
         </>
     );

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -435,6 +435,7 @@ export enum StatusIndicatorSize {
 }
 
 export interface OptionObject {
+    isDisabled?: boolean;
     label: string;
     value: string | number;
 }

--- a/src/app/utils/functions/financialFunctions.ts
+++ b/src/app/utils/functions/financialFunctions.ts
@@ -176,14 +176,16 @@ export const convertToLocaleValue = (value: number | string, locale: Locale): st
 // Add 00 if no decimals are present
 export const toCents = (value: number | string): number => {
     let stringValue = value.toString();
-    const decimalRegExp = /[.,][0-9]{2}$/;
+    const decimalRegExp2Digits = /[.][0-9]{2}$/;
+    const decimalRegExp1Digit = /[.][0-9]{1}$/;
 
-    if (decimalRegExp.test(stringValue)) {
+    if (decimalRegExp2Digits.test(stringValue)) {
         // Replace all . and , with nothing ;-)
         stringValue = stringValue.replace('.', '').replace(',', '');
+    } else if (decimalRegExp1Digit.test(stringValue)) {
+        stringValue = `${stringValue.replace('.', '').replace(',', '')}0`;
     } else {
         stringValue += '00';
     }
-
     return toNumber(stringValue);
 };

--- a/src/app/utils/functions/validateFunctions.ts
+++ b/src/app/utils/functions/validateFunctions.ts
@@ -1,7 +1,7 @@
-import { toCents, toMoneyValue } from './financialFunctions';
 import { DEFAULT_LOCALE } from '../../../global/constants';
 import { isDotDecimalCountry } from './localeFunctions';
 import { Locale } from '../../types';
+import { toMoneyValue } from './financialFunctions';
 import toNumber from './toNumber';
 
 export const isEmpty = (value: string | unknown | undefined | null | Array<unknown>): boolean => {
@@ -87,8 +87,7 @@ export const isValidNumber = (value: string, allowDecimals = false, locale?: Loc
 };
 
 // Always test against Locale.EN, because toMoneyValue will contain an EN format
-export const isValidMoney = (value: string, locale?: Locale): boolean =>
-    isValidNumber(toMoneyValue(toCents(value), locale || DEFAULT_LOCALE, true).toString(), true, Locale.EN);
+export const isValidMoney = (value: string, locale?: Locale): boolean => isValidNumber(value, true, locale);
 
 // **** BELOW SOME GENERIC VALIDATIONS USED BY SEVERAL COMPONENTS ****
 
@@ -99,7 +98,7 @@ export const isValidInputCurrency = (
     minValue?: number,
     maxValue?: number
 ): boolean => {
-    const numberValue = toMoneyValue(toCents(value || ''), locale, true);
+    const numberValue = toMoneyValue(value || '', locale);
 
     return (
         (!isRequired && (isEmpty(value) || value === '0')) ||


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Description of the pull request**:
- inputCurrency get the value as number so like this 1.51 or 1000.45 and convert it in inputValue to the string in the local format
- also validation is for the string in the local format, so we expect the user to enter a comma as the cent seperator and that is how currency is validated in Input.tsx
- onChange for currency is called after we convert it again to the money value . and that is why we don't call the onChange for every time we type a letter but when focus is lost because otherwise when you plan to type 1,50 you will get 1,00 after typing 1 and then you need to delete the 00 to type 5.



<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
