### PR TITLE
CW-1308 transition to dialog

### DIFF
--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -48,7 +48,7 @@ export const OverlayWrapper = styled.div<OverlayWrapperProps>`
 
 interface WrapperProps {
     height: number;
-    isResizeable: boolean;
+    isResizable: boolean;
     isScrollable: boolean;
     isVisible: boolean;
     size: DialogSize;
@@ -81,8 +81,8 @@ export const Wrapper = styled.div<WrapperProps>`
     max-height: 100%;
     overflow: 'visible';
 
-    ${({ isResizeable }): SimpleInterpolation =>
-        isResizeable &&
+    ${({ isResizable }): SimpleInterpolation =>
+        isResizable &&
         css`
             overflow: 'hidden';
         `}

--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -48,7 +48,7 @@ export const OverlayWrapper = styled.div<OverlayWrapperProps>`
 
 interface WrapperProps {
     height: number;
-    isResizable: boolean;
+    isResizeable: boolean;
     isScrollable: boolean;
     isVisible: boolean;
     size: DialogSize;
@@ -81,8 +81,8 @@ export const Wrapper = styled.div<WrapperProps>`
     max-height: 100%;
     overflow: 'visible';
 
-    ${({ isResizable }): SimpleInterpolation =>
-        isResizable &&
+    ${({ isResizeable }): SimpleInterpolation =>
+        isResizeable &&
         css`
             overflow: 'hidden';
         `}

--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -47,6 +47,8 @@ export const OverlayWrapper = styled.div<OverlayWrapperProps>`
 `;
 
 interface WrapperProps {
+    height: number;
+    isResizeable: boolean;
     isScrollable: boolean;
     isVisible: boolean;
     size: DialogSize;
@@ -75,8 +77,21 @@ export const Wrapper = styled.div<WrapperProps>`
     padding: ${({ isScrollable }): string => (isScrollable ? '0px' : `${widthScrollable}px`)};
     width: 100%;
     max-width: ${({ isScrollable, size }): string => `${dialogwidth(size, isScrollable)}px`};
+    height: ${({ height }): string => `${height}px`};
     max-height: 100%;
-    overflow: ${({ isScrollable }): string => (isScrollable ? 'auto' : 'visible')};
+    overflow: 'visible';
+
+    ${({ isResizeable }): SimpleInterpolation =>
+        isResizeable &&
+        css`
+            overflow: 'hidden';
+        `}
+
+    ${({ isScrollable }): SimpleInterpolation =>
+        isScrollable &&
+        css`
+            overflow: 'auto';
+        `}
     pointer-events: ${({ isVisible }): string => (isVisible ? 'auto' : 'none')};
 `;
 

--- a/src/app/components/organisms/Dialog/Dialog.stories.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.stories.tsx
@@ -13,10 +13,11 @@ import {
 import Dialog, { DialogProps } from './Dialog';
 import { DialogButtonClosePosition, IconPlacement } from './types';
 import moment, { Moment } from 'moment';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import Button from '../../molecules/Button/Button';
 import Input from '../../molecules/Input/Input';
 import { SingleDatePicker } from '../DatePicker';
+import { StyledTextWithOptionalIcon } from './Dialog.sc';
 import toNumber from '../../../utils/functions/toNumber';
 
 export default { title: 'organisms/Dialog' };
@@ -27,6 +28,7 @@ const ConfigurableDialog: FunctionComponent<DialogProps> = ({
     footerText,
     iconType,
     isScrollable,
+    isResizeable = false,
     isVisible,
     onClose,
     status,
@@ -45,6 +47,7 @@ const ConfigurableDialog: FunctionComponent<DialogProps> = ({
         header={text('Header', '')}
         iconPlacement={select('Icon placement', IconPlacement, IconPlacement.TOP)}
         iconType={iconType}
+        isResizeable={isResizeable}
         isScrollable={isScrollable}
         isVisible={isVisible}
         onClose={onClose}
@@ -109,8 +112,33 @@ export const Configurable: FunctionComponent = () => {
 };
 
 export const ConfigurableChangingHeight: FunctionComponent = () => {
+    // const largeHeight = <div style={{ height: '300px' }} />;
+    // const smallHeight = <div style={{ height: '100px' }} />;
+
+    const largeHeight = (
+        <>
+            <StyledTextWithOptionalIcon>{'This is the content of the large dialog'}</StyledTextWithOptionalIcon>
+            <Input label="Input" name="an-input-name" type={InputType.NUMBER} value={'1'} />
+            <Input label="Input" name="an-input-name" type={InputType.NUMBER} value={'2'} />
+            <Input label="Input" name="an-input-name" type={InputType.NUMBER} value={'3'} />
+        </>
+    );
+
+    const smallHeight = (
+        <StyledTextWithOptionalIcon>{'This is the content of the small dialog'}</StyledTextWithOptionalIcon>
+    );
+
     const [isVisible, setIsVisible] = useState(false);
     const [isLargeHeight, setIsLargeHeight] = useState(false);
+    const [dialogContent, setDialogContent] = useState(smallHeight);
+
+    useEffect(() => {
+        if (isLargeHeight) {
+            setDialogContent(largeHeight);
+        } else {
+            setDialogContent(smallHeight);
+        }
+    }, [isLargeHeight]);
 
     return (
         <>
@@ -134,14 +162,6 @@ export const ConfigurableChangingHeight: FunctionComponent = () => {
                         variant: ButtonVariant.TEXT_ONLY,
                     },
                     {
-                        children: 'Confirm',
-                        iconType: IconType.CHECK,
-                        onClick: (): void => {
-                            setIsVisible(false);
-                        },
-                        size: ButtonSize.SMALL,
-                    },
-                    {
                         children: 'Change height',
                         iconType: isLargeHeight ? IconType.ARROWUP : IconType.ARROWDOWN,
                         onClick: (): void => {
@@ -152,6 +172,7 @@ export const ConfigurableChangingHeight: FunctionComponent = () => {
                 ]}
                 footerText={text('Footer text', 'We need you..')}
                 iconType={select('Icon type', IconType, IconType.ROUND_ALERT)}
+                isResizeable
                 isVisible={isVisible}
                 onClose={(): void => {
                     setIsVisible(false);
@@ -162,7 +183,7 @@ export const ConfigurableChangingHeight: FunctionComponent = () => {
                 )}
                 title={text('Title', 'We should title this')}
             >
-                {isLargeHeight ? <div style={{ height: '300px' }} /> : <div style={{ height: '100px' }} />}
+                {dialogContent}
             </ConfigurableDialog>
         </>
     );

--- a/src/app/components/organisms/Dialog/Dialog.stories.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.stories.tsx
@@ -28,7 +28,7 @@ const ConfigurableDialog: FunctionComponent<DialogProps> = ({
     footerText,
     iconType,
     isScrollable,
-    isResizeable = false,
+    isResizable = false,
     isVisible,
     onClose,
     status,
@@ -47,7 +47,7 @@ const ConfigurableDialog: FunctionComponent<DialogProps> = ({
         header={text('Header', '')}
         iconPlacement={select('Icon placement', IconPlacement, IconPlacement.TOP)}
         iconType={iconType}
-        isResizeable={isResizeable}
+        isResizable={isResizable}
         isScrollable={isScrollable}
         isVisible={isVisible}
         onClose={onClose}
@@ -172,7 +172,7 @@ export const ConfigurableChangingHeight: FunctionComponent = () => {
                 ]}
                 footerText={text('Footer text', 'We need you..')}
                 iconType={select('Icon type', IconType, IconType.ROUND_ALERT)}
-                isResizeable
+                isResizable
                 isVisible={isVisible}
                 onClose={(): void => {
                     setIsVisible(false);

--- a/src/app/components/organisms/Dialog/Dialog.stories.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.stories.tsx
@@ -28,7 +28,7 @@ const ConfigurableDialog: FunctionComponent<DialogProps> = ({
     footerText,
     iconType,
     isScrollable,
-    isResizable = false,
+    isResizeable = false,
     isVisible,
     onClose,
     status,
@@ -47,7 +47,7 @@ const ConfigurableDialog: FunctionComponent<DialogProps> = ({
         header={text('Header', '')}
         iconPlacement={select('Icon placement', IconPlacement, IconPlacement.TOP)}
         iconType={iconType}
-        isResizable={isResizable}
+        isResizeable={isResizeable}
         isScrollable={isScrollable}
         isVisible={isVisible}
         onClose={onClose}
@@ -172,7 +172,7 @@ export const ConfigurableChangingHeight: FunctionComponent = () => {
                 ]}
                 footerText={text('Footer text', 'We need you..')}
                 iconType={select('Icon type', IconType, IconType.ROUND_ALERT)}
-                isResizable
+                isResizeable
                 isVisible={isVisible}
                 onClose={(): void => {
                     setIsVisible(false);

--- a/src/app/components/organisms/Dialog/Dialog.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.tsx
@@ -15,7 +15,7 @@ import { DialogButtonClosePosition, IconPlacement } from './types';
 import DialogFooter, { DialogFooterProps } from '../../molecules/DialogFooter/DialogFooter';
 import { DialogSize, Easing, Elevation, IconType, Status } from '../../../types';
 import { IconCustomizable, IconCustomizableSize } from '../../molecules/IconCustomizable';
-import React, { FunctionComponent, MouseEventHandler, ReactNode } from 'react';
+import React, { FunctionComponent, MouseEventHandler, ReactNode, useEffect, useRef, useState } from 'react';
 import { IconProps } from '../../atoms/Icon/Icon';
 import { isEmpty } from '../../../utils/functions/validateFunctions';
 import Overlay from '../../molecules/Overlay/Overlay';
@@ -34,6 +34,7 @@ export interface DialogProps {
     header?: ReactNode;
     iconPlacement?: IconPlacement;
     iconType?: IconProps['type'] /* IconType will be used by title and inside content */;
+    isResizeable?: boolean;
     isScrollable?: boolean;
     isVisible: boolean;
     onClose?: MouseEventHandler;
@@ -60,6 +61,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
     iconPlacement = IconPlacement.TOP,
     iconType,
     isScrollable = true,
+    isResizeable = false,
     isVisible,
     onClose,
     size = DialogSize.DEFAULT,
@@ -68,53 +70,65 @@ export const Dialog: FunctionComponent<DialogProps> = ({
     title,
     transitionDuration = 300,
     transitionEasing = Easing.EASE,
-}) => (
-    <>
-        {hasOverlay && (
-            <OverlayWrapper isVisible={isVisible}>
-                <Overlay isVisible={isVisible} />
-            </OverlayWrapper>
-        )}
-        {hasButtonClose && hasOverlay && isVisible && (
-            <ButtonClose onClick={onClose} position={buttonClosePosition}>
-                <IconCustomizable iconSize={IconCustomizableSize.SIZE24} iconType={IconType.CROSS} />
-            </ButtonClose>
-        )}
-        <Wrapper
-            className={className}
-            isScrollable={isScrollable}
-            isVisible={isVisible}
-            size={size}
-            transitionDuration={transitionDuration}
-            transitionEasing={transitionEasing}
-        >
-            <StyledDialog elevation={elevation} isScrollable={isScrollable}>
-                {header && <Header hasHeaderPadding={hasHeaderPadding}>{header}</Header>}
-                <Body hasBodyPadding={hasBodyPadding} hasBorderRadius={isEmpty(header)}>
-                    {iconType && title && (
-                        <StyledTextWithOptionalIcon iconType={iconType}>{title}</StyledTextWithOptionalIcon>
-                    )}
-                    <Content iconPlacement={iconPlacement}>
-                        {iconType && !title && (
-                            <IconWrapper status={status}>
-                                <IconCustomizable iconSize={IconCustomizableSize.SIZE32} iconType={iconType} />
-                            </IconWrapper>
+}) => {
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const [key, setKey] = useState(1);
+
+    useEffect(() => {
+        setKey(key + 1);
+    }, [children]);
+
+    return (
+        <>
+            {hasOverlay && (
+                <OverlayWrapper isVisible={isVisible}>
+                    <Overlay isVisible={isVisible} />
+                </OverlayWrapper>
+            )}
+            {hasButtonClose && hasOverlay && isVisible && (
+                <ButtonClose onClick={onClose} position={buttonClosePosition}>
+                    <IconCustomizable iconSize={IconCustomizableSize.SIZE24} iconType={IconType.CROSS} />
+                </ButtonClose>
+            )}
+            <Wrapper
+                className={className}
+                height={dialogRef.current?.clientHeight || 0}
+                isResizeable={isResizeable}
+                isScrollable={isScrollable}
+                isVisible={isVisible}
+                size={size}
+                transitionDuration={transitionDuration}
+                transitionEasing={transitionEasing}
+            >
+                <StyledDialog elevation={elevation} isScrollable={isScrollable} ref={dialogRef}>
+                    {header && <Header hasHeaderPadding={hasHeaderPadding}>{header}</Header>}
+                    <Body hasBodyPadding={hasBodyPadding} hasBorderRadius={isEmpty(header)}>
+                        {iconType && title && (
+                            <StyledTextWithOptionalIcon iconType={iconType}>{title}</StyledTextWithOptionalIcon>
                         )}
-                        {text && <Text>{text}</Text>}
-                    </Content>
-                    {children && (
-                        <ChildrenWrapper
-                            hasPaddingLeft={Boolean(iconType) && Boolean(text) && !title}
-                            hasPaddingTop={Boolean(iconType) || Boolean(text)}
-                        >
-                            {children}
-                        </ChildrenWrapper>
-                    )}
-                </Body>
-                <DialogFooter buttons={footerButtons} text={footerText} />
-            </StyledDialog>
-        </Wrapper>
-    </>
-);
+                        <Content iconPlacement={iconPlacement}>
+                            {iconType && !title && (
+                                <IconWrapper status={status}>
+                                    <IconCustomizable iconSize={IconCustomizableSize.SIZE32} iconType={iconType} />
+                                </IconWrapper>
+                            )}
+                            {text && <Text>{text}</Text>}
+                        </Content>
+                        {children && (
+                            <ChildrenWrapper
+                                hasPaddingLeft={Boolean(iconType) && Boolean(text) && !title}
+                                hasPaddingTop={Boolean(iconType) || Boolean(text)}
+                                key={key}
+                            >
+                                {children}
+                            </ChildrenWrapper>
+                        )}
+                    </Body>
+                    <DialogFooter buttons={footerButtons} text={footerText} />
+                </StyledDialog>
+            </Wrapper>
+        </>
+    );
+};
 
 export default Dialog;

--- a/src/app/components/organisms/Dialog/Dialog.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.tsx
@@ -34,7 +34,7 @@ export interface DialogProps {
     header?: ReactNode;
     iconPlacement?: IconPlacement;
     iconType?: IconProps['type'] /* IconType will be used by title and inside content */;
-    isResizeable?: boolean;
+    isResizable?: boolean;
     isScrollable?: boolean;
     isVisible: boolean;
     onClose?: MouseEventHandler;
@@ -61,7 +61,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
     iconPlacement = IconPlacement.TOP,
     iconType,
     isScrollable = true,
-    isResizeable = false,
+    isResizable = false,
     isVisible,
     onClose,
     size = DialogSize.DEFAULT,
@@ -93,7 +93,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
             <Wrapper
                 className={className}
                 height={dialogRef.current?.clientHeight || 0}
-                isResizeable={isResizeable}
+                isResizable={isResizable}
                 isScrollable={isScrollable}
                 isVisible={isVisible}
                 size={size}

--- a/src/app/components/organisms/Dialog/Dialog.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.tsx
@@ -34,7 +34,7 @@ export interface DialogProps {
     header?: ReactNode;
     iconPlacement?: IconPlacement;
     iconType?: IconProps['type'] /* IconType will be used by title and inside content */;
-    isResizable?: boolean;
+    isResizeable?: boolean;
     isScrollable?: boolean;
     isVisible: boolean;
     onClose?: MouseEventHandler;
@@ -61,7 +61,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
     iconPlacement = IconPlacement.TOP,
     iconType,
     isScrollable = true,
-    isResizable = false,
+    isResizeable = false,
     isVisible,
     onClose,
     size = DialogSize.DEFAULT,
@@ -93,7 +93,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
             <Wrapper
                 className={className}
                 height={dialogRef.current?.clientHeight || 0}
-                isResizable={isResizable}
+                isResizeable={isResizeable}
                 isScrollable={isScrollable}
                 isVisible={isVisible}
                 size={size}


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1308

**Description of the pull request**:
- add height to the element in order to transition on the height.
- the height is fetched with reference to DOM element
- overflow: hidden is also needed otherwise we have for a moment a scrolbar, 
but we also use the overflow property for scrolling vs. dialogs with datePicker so I added a property isResizable in order to to interfere with the functionality of a dialog with a datePicker.
isResizable is only needed when the content of the dialog is going to change when you confirm

the way to use in CW: 
don't rerender a whole dialog, the next step is to rerender only the props children, buttons, title en text of the same dialog

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
