### PR TITLE
CW-1339 improve divide space between footer text and buttons

### DIFF
--- a/src/app/components/molecules/DialogFooter/DialogFooter.sc.ts
+++ b/src/app/components/molecules/DialogFooter/DialogFooter.sc.ts
@@ -7,6 +7,7 @@ export const StyledDialogFooter = styled.footer`
     ${setBoxSizing()}
     display: flex;
     align-items: center;
+    justify-content: right;
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
     background-color: ${({ theme }): string => theme.shades.seven};
@@ -19,7 +20,6 @@ StyledDialogFooter.defaultProps = {
 
 export const Text = styled.p`
     ${({ theme }): string => theme.textStyling(theme.availableTextStyles().caption)}
-    flex-shrink: 2;
     margin: 0;
     padding: ${({ theme }): string => theme.spacing(0, 2, 0, 0)};
     width: 100%;
@@ -32,14 +32,17 @@ Text.defaultProps = {
 };
 
 interface ButtonBarWrapperProps {
-    hasFullWidth: boolean;
+    alignment: Alignment;
 }
 
 export const ButtonBarWrapper = styled.div<ButtonBarWrapperProps>`
-    ${({ hasFullWidth }): SimpleInterpolation =>
-        hasFullWidth &&
+    display: flex;
+    justify-content: ${({ alignment }): string => (alignment === Alignment.LEFT ? 'left' : 'right')};
+
+    ${({ alignment }): SimpleInterpolation =>
+        alignment === Alignment.LEFT &&
         css`
-            width: 100%;
+            flex-grow: 1;
         `}
 
     text-align: right;
@@ -56,7 +59,6 @@ export const ButtonWrapper = styled.div<ButtonWrapperProps>`
         theme.spacing(0, alignment === Alignment.LEFT ? 0.5 : 1, 0, alignment === Alignment.LEFT ? 0 : 1)};
     min-height: ${({ theme }): string => theme.spacing(4)};
     vertical-align: middle;
-    ${({ alignment }) => alignment === Alignment.LEFT && 'float: left;'}
 
     &:last-of-type {
         margin-right: 0;

--- a/src/app/components/molecules/DialogFooter/DialogFooter.tsx
+++ b/src/app/components/molecules/DialogFooter/DialogFooter.tsx
@@ -16,20 +16,38 @@ export interface DialogFooterProps {
     text?: ReactNode;
 }
 
-export const DialogFooter: FunctionComponent<DialogFooterProps> = ({ buttons = [], className, text }) => (
-    <StyledDialogFooter className={className}>
-        {/* This might need to be moved if there are buttons with alignment Left, but for now, this is ok */}
-        {text && <Text>{text}</Text>}
-        <ButtonBarWrapper hasFullWidth={buttons && (isEmpty(text) || buttons.length > 1)}>
-            {buttons.map((button, index) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <ButtonWrapper alignment={button.alignment} key={index}>
-                    {/* eslint-disable-next-line react/no-array-index-key */}
-                    <Button {...button}>{button.children}</Button>
-                </ButtonWrapper>
-            ))}
-        </ButtonBarWrapper>
-    </StyledDialogFooter>
-);
+export const DialogFooter: FunctionComponent<DialogFooterProps> = ({ buttons = [], className, text }) => {
+    const buttonsLeft = buttons.filter((button) => button.alignment && button.alignment === Alignment.LEFT);
+    const buttonsRight = buttons.filter((button) => !button.alignment || button.alignment === Alignment.RIGHT);
+
+    return (
+        <StyledDialogFooter className={className}>
+            {/* This might need to be moved if there are buttons with alignment Left, but for now, this is ok */}
+            {text && <Text>{text}</Text>}
+            {!isEmpty(buttonsLeft) && (
+                <ButtonBarWrapper alignment={Alignment.LEFT}>
+                    {buttonsLeft.map((button, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <ButtonWrapper alignment={button.alignment} key={index}>
+                            {/* eslint-disable-next-line react/no-array-index-key */}
+                            <Button {...button}>{button.children}</Button>
+                        </ButtonWrapper>
+                    ))}
+                </ButtonBarWrapper>
+            )}
+            {!isEmpty(buttonsRight) && (
+                <ButtonBarWrapper alignment={Alignment.RIGHT}>
+                    {buttonsRight.map((button, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <ButtonWrapper alignment={button.alignment} key={index}>
+                            {/* eslint-disable-next-line react/no-array-index-key */}
+                            <Button {...button}>{button.children}</Button>
+                        </ButtonWrapper>
+                    ))}
+                </ButtonBarWrapper>
+            )}
+        </StyledDialogFooter>
+    );
+};
 
 export default DialogFooter;


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

removed the use of shrink: 2 because shrink:1 is nog enough when the buttons have long text that means that if the buttons have a longer text then shrink: 2 also won't be enough so it is better not to use it. 
Also float: left is not the best way to align items, better use flex-box.

tested in all story book dialog en footerDialog, with and without footerText and with aligning buttons icons to the left in footerDialog.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
