### PR TITLE
CW-1281 replace position fixed with position absolute so that it could be scr…

### DIFF
--- a/src/app/components/organisms/Dialog/Dialog.sc.ts
+++ b/src/app/components/organisms/Dialog/Dialog.sc.ts
@@ -32,12 +32,18 @@ const dialogwidth = (size: DialogSize, isScrollable: boolean): number => {
     return isScrollable ? width - widthScrollable : width;
 };
 
+export const StyledDialogwrapper = styled.div`
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+`;
+
 interface OverlayWrapperProps {
     isVisible: boolean;
 }
 
 export const OverlayWrapper = styled.div<OverlayWrapperProps>`
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     z-index: ${zIndex.DIALOG - 2};
@@ -71,7 +77,7 @@ export const Wrapper = styled.div<WrapperProps>`
             easing: transitionEasing,
             isVisible,
         })}
-    position: fixed;
+    position: absolute;
     opacity: ${({ isVisible }): number => (isVisible ? 1 : 0)};
     z-index: ${zIndex.DIALOG - 1};
     padding: ${({ isScrollable }): string => (isScrollable ? '0px' : `${widthScrollable}px`)};

--- a/src/app/components/organisms/Dialog/Dialog.tsx
+++ b/src/app/components/organisms/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import {
     IconWrapper,
     OverlayWrapper,
     StyledDialog,
+    StyledDialogwrapper,
     StyledTextWithOptionalIcon,
     Text,
     Wrapper,
@@ -74,7 +75,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
     const dialogRef = useRef<HTMLDivElement>(null);
 
     return (
-        <>
+        <StyledDialogwrapper>
             {hasOverlay && (
                 <OverlayWrapper isVisible={isVisible}>
                     <Overlay isVisible={isVisible} />
@@ -121,7 +122,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
                     <DialogFooter buttons={footerButtons} text={footerText} />
                 </StyledDialog>
             </Wrapper>
-        </>
+        </StyledDialogwrapper>
     );
 };
 


### PR DESCRIPTION
…olled to reveal the rest of the dialog

### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1281

**Description of the pull request**:
- instead of position fixed that takes a div out of the container div and positions it in the window, position the dialog with the same condition inside another div that has 100% length and width. that way we can scroll the container div if the dialog is not completely visible in a smaller screen or landscape view.


<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
