### PR TITLE
CW-1139 isLaoding as props, the instances are always defined

### DIFF
--- a/src/app/components/organisms/PicklistMultiSelect/PicklistMultiSelect.stories.tsx
+++ b/src/app/components/organisms/PicklistMultiSelect/PicklistMultiSelect.stories.tsx
@@ -54,6 +54,7 @@ export const Configurable: FunctionComponent = () => {
             fitToScreen={boolean('Fit to screen', false)}
             hasPaging={boolean('Has paging', true)}
             isDisabled={boolean('Is disabled', false)}
+            isLoading={boolean('Is loading', false)}
             onChange={onChange}
             options={{ sortBy }}
             paginatorTexts={paginatorTexts}

--- a/src/app/components/organisms/PicklistMultiSelect/PicklistMultiSelect.tsx
+++ b/src/app/components/organisms/PicklistMultiSelect/PicklistMultiSelect.tsx
@@ -34,6 +34,7 @@ export interface PicklistMultiSelectProps<T extends object, U extends T & Pickli
     fitToScreen?: boolean; // maximizes height and only applies with hasPaging = false
     hasPaging?: boolean;
     isDisabled?: boolean;
+    isLoading?: boolean;
     locale?: Locale;
     onChange?: (removed: T[], added: T[], updated: T[]) => void;
     options: Partial<TableState<T>>;
@@ -63,6 +64,7 @@ export const PicklistMultiSelect = <T extends object, U extends T & PicklistMult
     fitToScreen = false,
     hasPaging = true,
     isDisabled = false,
+    isLoading = false,
     locale = DEFAULT_LOCALE,
     onChange,
     options,
@@ -149,11 +151,7 @@ export const PicklistMultiSelect = <T extends object, U extends T & PicklistMult
                     options={
                         <Button
                             iconType={IconType.ARROWRIGHT}
-                            isDisabled={
-                                isDisabled ||
-                                !availableOptionsInstance ||
-                                isEmpty(availableOptionsInstance.selectedFlatRows)
-                            }
+                            isDisabled={isDisabled || isEmpty(availableOptionsInstance.selectedFlatRows)}
                             onClick={onAddToSelectionCallback}
                             size={ButtonSize.SMALL}
                             variant={ButtonVariant.OUTLINE}
@@ -164,7 +162,7 @@ export const PicklistMultiSelect = <T extends object, U extends T & PicklistMult
                     status={availablePanelProps.status || Status.DEFAULT}
                     title={availablePanelProps.title}
                 />
-                {!availableOptionsInstance ? (
+                {isLoading ? (
                     <StyledLoader>
                         <TableSkeleton numberOfRowsPerTable={LOADING_NR_OF_ROWS} showRowsInCard />
                     </StyledLoader>
@@ -199,11 +197,7 @@ export const PicklistMultiSelect = <T extends object, U extends T & PicklistMult
                     options={
                         <Button
                             iconType={IconType.ARROWLEFT}
-                            isDisabled={
-                                isDisabled ||
-                                !selectedOptionsInstance ||
-                                isEmpty(selectedOptionsInstance.selectedFlatRows)
-                            }
+                            isDisabled={isDisabled || isEmpty(selectedOptionsInstance.selectedFlatRows)}
                             onClick={onRemoveFromSelectionCallback}
                             size={ButtonSize.SMALL}
                             variant={ButtonVariant.OUTLINE}
@@ -214,7 +208,7 @@ export const PicklistMultiSelect = <T extends object, U extends T & PicklistMult
                     status={selectedPanelProps.status || Status.DEFAULT}
                     title={selectedPanelProps.title}
                 />
-                {!selectedOptionsInstance ? (
+                {isLoading ? (
                     <StyledLoader>
                         <TableSkeleton numberOfRowsPerTable={LOADING_NR_OF_ROWS} showRowsInCard />
                     </StyledLoader>


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
*https://jira.sportlink.nl/browse/CW-1139

**Description of the pull request**:
- isLoading should be a prop because we will use it to show a state while waiting for a BE call to return
- showing skeletons with conditions on the instances will never show skeletons because the instances are ALWAYS defined. 

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
