### PR TITLE
CW-1344 input type number support for safari and firefox

### DIFF
--- a/src/app/components/molecules/Input/Input.stories.tsx
+++ b/src/app/components/molecules/Input/Input.stories.tsx
@@ -32,7 +32,7 @@ export const Configurable: FunctionComponent = () => {
                 setValue(currentTarget.value);
             }}
             onFocus={action('On focus')}
-            type={select('Type', InputType, InputType.NUMBER)}
+            type={select('Type', InputType, InputType.TEXT)}
             value={value}
             variant={select('Variant', InputVariant, InputVariant.OUTLINE)}
         />

--- a/src/app/components/molecules/Input/Input.stories.tsx
+++ b/src/app/components/molecules/Input/Input.stories.tsx
@@ -28,10 +28,11 @@ export const Configurable: FunctionComponent = () => {
             name="an-input-name"
             onBlur={action('On blur')}
             onChange={({ currentTarget }): void => {
+                console.log(currentTarget);
                 setValue(currentTarget.value);
             }}
             onFocus={action('On focus')}
-            type={select('Type', InputType, InputType.TEXT)}
+            type={select('Type', InputType, InputType.NUMBER)}
             value={value}
             variant={select('Variant', InputVariant, InputVariant.OUTLINE)}
         />

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -150,6 +150,17 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     const onChangeCallback = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
             let newValue = event.currentTarget.value;
+            let hasChanges = true;
+
+            // don't allow typing letters, Firefox and Safari ignore the input type
+            if (type === InputType.NUMBER) {
+                const regex = RegExp(/[0-9]+/g);
+
+                if (!regex.test(newValue)) {
+                    newValue = inputDisplayValue;
+                    hasChanges = false;
+                }
+            }
 
             if (type !== InputType.CURRENCY) {
                 // for currency no manipulation of the value before loosing focus
@@ -166,7 +177,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                 setInputValue(newValue);
             }
 
-            if (onChange && (type !== InputType.CURRENCY || isOnChangeRequired)) {
+            if (hasChanges && onChange && (type !== InputType.CURRENCY || isOnChangeRequired)) {
                 onChange({
                     ...event,
                     currentTarget: {
@@ -176,7 +187,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                 } as ChangeEvent<HTMLInputElement>);
             }
         },
-        [onChange]
+        [onChange, inputDisplayValue, isOnChangeRequired]
     );
 
     const onFocusCallback = useCallback(

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -9,6 +9,7 @@ import {
     isValidInputTelephone,
     isValidInputText,
     isValidInputURI,
+    isValidNumber,
 } from '../../../utils/functions/validateFunctions';
 import React, {
     ChangeEvent,
@@ -153,13 +154,9 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
             let hasChanges = true;
 
             // don't allow typing letters, Firefox and Safari ignore the input type
-            if (type === InputType.NUMBER) {
-                const regex = RegExp(/[0-9]+/g);
-
-                if (!isEmpty(newValue) && !regex.test(newValue)) {
-                    newValue = inputDisplayValue;
-                    hasChanges = false;
-                }
+            if (!isEmpty(newValue) && type === InputType.NUMBER && !isValidNumber(newValue)) {
+                newValue = inputDisplayValue;
+                hasChanges = false;
             }
 
             if (type !== InputType.CURRENCY) {

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -156,7 +156,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
             if (type === InputType.NUMBER) {
                 const regex = RegExp(/[0-9]+/g);
 
-                if (!regex.test(newValue)) {
+                if (!isEmpty(newValue) && !regex.test(newValue)) {
                     newValue = inputDisplayValue;
                     hasChanges = false;
                 }


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

**Jira link**:
https://jira.sportlink.nl/browse/CW-1344

**Description of the pull request**:
- safari and firefox ignore input type="number", the typed input needs to be validated and if someone typed a letter don't accept is as new input value.

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
