### PR TITLE
CW-1469: implement isRequired prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dexels-ui-kit",
-    "version": "5.27.14",
+    "version": "5.27.15",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dexels-ui-kit",
-    "version": "5.27.14",
+    "version": "5.27.15",
     "author": {
         "name": "Dexels B.V.",
         "email": "info@dexels.com"

--- a/src/app/components/atoms/RequiredIndicator/RequiredIndicator.sc.ts
+++ b/src/app/components/atoms/RequiredIndicator/RequiredIndicator.sc.ts
@@ -1,0 +1,22 @@
+import styled, { css, SimpleInterpolation } from 'styled-components';
+import { themeBasic } from '../../../styles/theming/themes/basic';
+
+interface StyledRequiredIndicatorProps {
+    isDisabled: boolean;
+}
+
+export const StyledRequiredIndicator = styled.span<StyledRequiredIndicatorProps>`
+    color: ${({ theme }): string => theme.colorAlert};
+
+    ${({ isDisabled, theme }): SimpleInterpolation =>
+        isDisabled &&
+        css`
+            color: ${theme.colorDisabled};
+        `}
+`;
+
+StyledRequiredIndicator.defaultProps = {
+    theme: themeBasic,
+};
+
+export default StyledRequiredIndicator;

--- a/src/app/components/atoms/RequiredIndicator/RequiredIndicator.tsx
+++ b/src/app/components/atoms/RequiredIndicator/RequiredIndicator.tsx
@@ -1,0 +1,20 @@
+import React, { FunctionComponent } from 'react';
+import { REQUIRED_INDICATOR } from '../../../../global/constants';
+import { StyledRequiredIndicator } from './RequiredIndicator.sc';
+
+export interface RequiredIndicatorProps {
+    hasLeadingSpace?: boolean;
+    isDisabled?: boolean;
+}
+
+export const RequiredIndicator: FunctionComponent<RequiredIndicatorProps> = ({
+    hasLeadingSpace = true,
+    isDisabled = false,
+}) => (
+    <StyledRequiredIndicator isDisabled={isDisabled}>
+        {hasLeadingSpace && ` `}
+        {REQUIRED_INDICATOR}
+    </StyledRequiredIndicator>
+);
+
+export default RequiredIndicator;

--- a/src/app/components/molecules/Dropdown/Dropdown.stories.tsx
+++ b/src/app/components/molecules/Dropdown/Dropdown.stories.tsx
@@ -22,6 +22,7 @@ export const ConfigurableCompactVariant: FunctionComponent = () => {
                 errorMessage={text('Error message', 'Everything is broken, oops')}
                 hasError={boolean('Has error', false)}
                 isDisabled={boolean('Is disabled', false)}
+                isRequired={boolean('Is required', false)}
                 isValid={boolean('Is valid', false)}
                 name="the-best-fruit"
                 onChange={(event): void => {
@@ -53,6 +54,7 @@ export const ConfigurableOutlineVariant: FunctionComponent = () => {
                 errorMessage={text('Error message', 'Everything is broken, oops')}
                 hasError={boolean('Has error', false)}
                 isDisabled={boolean('Is disabled', false)}
+                isRequired={boolean('Is required', false)}
                 isValid={boolean('Is valid', false)}
                 label="Your favorite fruit"
                 name="the-best-fruit"
@@ -75,6 +77,7 @@ export const ConfigurableEmptyOptions: FunctionComponent = () => (
         errorMessage={text('Error message', 'Everything is broken, oops')}
         hasError={boolean('Has error', false)}
         isDisabled={boolean('Is disabled', false)}
+        isRequired={boolean('Is required', false)}
         isValid={boolean('Is valid', false)}
         name="the-best-empty-fruit"
         noOptionsText={text('No options text', 'No options')}

--- a/src/app/components/molecules/Dropdown/Dropdown.tsx
+++ b/src/app/components/molecules/Dropdown/Dropdown.tsx
@@ -87,6 +87,7 @@ export const Dropdown: FunctionComponent<DropdownProps & { [key: string]: any }>
                         isDisabled={isDisabled}
                         isFocused={isFocused || isOpen}
                         isHovered={isHovered}
+                        isRequired={isRequired}
                         isValid={isValid}
                     >
                         {label}

--- a/src/app/components/molecules/FormElementLabel/FormElementLabel.stories.tsx
+++ b/src/app/components/molecules/FormElementLabel/FormElementLabel.stories.tsx
@@ -12,6 +12,7 @@ export const Configurable: FunctionComponent = () => (
         isActive={boolean('Is active', true)}
         isDisabled={boolean('Is disabled', false)}
         isFocused={boolean('Is focused', false)}
+        isRequired={boolean('Is required', false)}
         isValid={boolean('Is valid', false)}
         variant={select('Variant', InputVariant, InputVariant.OUTLINE)}
     >

--- a/src/app/components/molecules/FormElementLabel/FormElementLabel.tsx
+++ b/src/app/components/molecules/FormElementLabel/FormElementLabel.tsx
@@ -1,6 +1,7 @@
 import { AdornmentPosition, InputVariant } from '../../../types';
 import React, { FunctionComponent, ReactNode } from 'react';
 import Label from '../../atoms/Label/Label';
+import { REQUIRED_INDICATOR } from '../../../../global/constants';
 import { StyledFormElementLabel } from './FormElementLabel.sc';
 
 export interface FormElementLabelProps {
@@ -14,6 +15,7 @@ export interface FormElementLabelProps {
     isDisabled?: boolean;
     isFocused?: boolean;
     isHovered?: boolean;
+    isRequired?: boolean;
     isValid?: boolean;
     variant?: InputVariant;
 }
@@ -29,6 +31,7 @@ export const FormElementLabel: FunctionComponent<FormElementLabelProps> = ({
     isDisabled = false,
     isFocused = false,
     isHovered = false,
+    isRequired = false,
     isValid = false,
     variant = InputVariant.OUTLINE,
 }) => {
@@ -54,6 +57,7 @@ export const FormElementLabel: FunctionComponent<FormElementLabelProps> = ({
                 isValid={isValid}
             >
                 {children}
+                {isRequired && ` ${REQUIRED_INDICATOR}`}
             </Label>
         </StyledFormElementLabel>
     );

--- a/src/app/components/molecules/FormElementLabel/FormElementLabel.tsx
+++ b/src/app/components/molecules/FormElementLabel/FormElementLabel.tsx
@@ -1,7 +1,7 @@
 import { AdornmentPosition, InputVariant } from '../../../types';
 import React, { FunctionComponent, ReactNode } from 'react';
 import Label from '../../atoms/Label/Label';
-import { REQUIRED_INDICATOR } from '../../../../global/constants';
+import RequiredIndicator from '../../atoms/RequiredIndicator/RequiredIndicator';
 import { StyledFormElementLabel } from './FormElementLabel.sc';
 
 export interface FormElementLabelProps {
@@ -57,7 +57,7 @@ export const FormElementLabel: FunctionComponent<FormElementLabelProps> = ({
                 isValid={isValid}
             >
                 {children}
-                {isRequired && ` ${REQUIRED_INDICATOR}`}
+                {isRequired && <RequiredIndicator isDisabled={isDisabled} />}
             </Label>
         </StyledFormElementLabel>
     );

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -102,11 +102,6 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     const hasValue = !isEmpty(inputDisplayValue);
     const textFieldProps: { [key: string]: number } = {};
 
-    console.log('hasError', hasError);
-    console.log('isRequired', isRequired);
-    console.log('hasValue', hasValue);
-    console.log('value', value);
-
     // Because this check might be performed in several actions, put it here
     const isValidInput = useCallback(
         (valueToValidate: string): boolean => {

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -252,23 +252,26 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     }, [value]);
 
     useEffect(() => {
-        // for currency also check the temporary inputValue
-        const validation =
-            type === InputType.CURRENCY
-                ? isValidInput(inputDisplayValue) &&
-                  (isEmpty(inputValue) || isValidInputNumber(inputValue, locale, isRequired, min, max))
-                : isValidInput(inputDisplayValue);
+        // Consider a required, but empty input as valid for display purposes
+        if (!hasValue && isRequired) {
+            setIsValidInputData(true);
+        } else {
+            // for currency also check the temporary inputValue
+            const validation =
+                type === InputType.CURRENCY
+                    ? isValidInput(inputDisplayValue) &&
+                      (isEmpty(inputValue) || isValidInputNumber(inputValue, locale, isRequired, min, max))
+                    : isValidInput(inputDisplayValue);
 
-        setIsValidInputData(validation);
-    }, [inputDisplayValue, inputValue]);
-
-    // Consider a required, but empty input as valid for display purposes
+            setIsValidInputData(validation);
+        }
+    }, [hasValue, inputDisplayValue, inputValue]);
 
     return (
         <>
             <StyledInput
                 className={className}
-                hasError={hasError || (!isValidInputData && hasValue)}
+                hasError={hasError || !isValidInputData}
                 isClickable={!isDisabled && Boolean(onClick)}
                 isDisabled={isDisabled}
                 isFocused={isFocused}
@@ -283,7 +286,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     as={isTextarea ? 'textarea' : 'input'}
                     autoFocus={autoFocus}
                     hasAdornment={adornment !== undefined}
-                    hasError={hasError || (!isValidInputData && hasValue)}
+                    hasError={hasError || !isValidInputData}
                     hasNegativeAmountColor={
                         hasNegativeAmountColor && !isEmpty(inputDisplayValue) && toNumber(inputDisplayValue) < 0
                     }
@@ -312,7 +315,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     <FormElementLabel
                         adornmentPosition={adornmentPosition}
                         hasAdornment={adornment !== undefined}
-                        hasError={hasError || (!isValidInputData && hasValue)}
+                        hasError={hasError || !isValidInputData}
                         isActive={hasValue}
                         isDisabled={isDisabled}
                         isFocused={isFocused}
@@ -328,7 +331,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                 {adornment && (
                     <AdornmentWrapper
                         adornmentPosition={adornmentPosition}
-                        hasError={hasError || (!isValidInputData && hasValue)}
+                        hasError={hasError || !isValidInputData}
                         hasValue={hasValue}
                         isDisabled={isDisabled}
                         isFocused={isFocused}
@@ -340,7 +343,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     </AdornmentWrapper>
                 )}
             </StyledInput>
-            {errorMessage && (hasError || (!isValidInputData && hasValue)) && !isDisabled && (
+            {errorMessage && (hasError || !isValidInputData) && !isDisabled && (
                 <ErrorMessage isOutlineVariant={variant === InputVariant.OUTLINE && !ignoreOutlineVariant}>
                     {errorMessage}
                 </ErrorMessage>

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -102,6 +102,11 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     const hasValue = !isEmpty(inputDisplayValue);
     const textFieldProps: { [key: string]: number } = {};
 
+    console.log('hasError', hasError);
+    console.log('isRequired', isRequired);
+    console.log('hasValue', hasValue);
+    console.log('value', value);
+
     // Because this check might be performed in several actions, put it here
     const isValidInput = useCallback(
         (valueToValidate: string): boolean => {
@@ -252,8 +257,11 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
     }, [value]);
 
     useEffect(() => {
-        // Consider a required, but empty input as valid for display purposes
-        if (!hasValue && isRequired) {
+        // Consider a required, but empty input as valid for display purposes.
+        // Only when there's actually input, than hasError gets to be an effect
+        if (hasError && hasValue) {
+            setIsValidInputData(false);
+        } else if (!hasValue && isRequired) {
             setIsValidInputData(true);
         } else {
             // for currency also check the temporary inputValue
@@ -265,13 +273,13 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
 
             setIsValidInputData(validation);
         }
-    }, [hasValue, inputDisplayValue, inputValue]);
+    }, [hasError, hasValue, inputDisplayValue, inputValue]);
 
     return (
         <>
             <StyledInput
                 className={className}
-                hasError={hasError || !isValidInputData}
+                hasError={!isValidInputData}
                 isClickable={!isDisabled && Boolean(onClick)}
                 isDisabled={isDisabled}
                 isFocused={isFocused}
@@ -286,7 +294,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     as={isTextarea ? 'textarea' : 'input'}
                     autoFocus={autoFocus}
                     hasAdornment={adornment !== undefined}
-                    hasError={hasError || !isValidInputData}
+                    hasError={!isValidInputData}
                     hasNegativeAmountColor={
                         hasNegativeAmountColor && !isEmpty(inputDisplayValue) && toNumber(inputDisplayValue) < 0
                     }
@@ -315,7 +323,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     <FormElementLabel
                         adornmentPosition={adornmentPosition}
                         hasAdornment={adornment !== undefined}
-                        hasError={hasError || !isValidInputData}
+                        hasError={!isValidInputData}
                         isActive={hasValue}
                         isDisabled={isDisabled}
                         isFocused={isFocused}
@@ -331,7 +339,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                 {adornment && (
                     <AdornmentWrapper
                         adornmentPosition={adornmentPosition}
-                        hasError={hasError || !isValidInputData}
+                        hasError={!isValidInputData}
                         hasValue={hasValue}
                         isDisabled={isDisabled}
                         isFocused={isFocused}
@@ -343,7 +351,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     </AdornmentWrapper>
                 )}
             </StyledInput>
-            {errorMessage && (hasError || !isValidInputData) && !isDisabled && (
+            {errorMessage && !isValidInputData && !isDisabled && (
                 <ErrorMessage isOutlineVariant={variant === InputVariant.OUTLINE && !ignoreOutlineVariant}>
                     {errorMessage}
                 </ErrorMessage>

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -253,7 +253,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
 
     useEffect(() => {
         // Consider a required, but empty input as valid for display purposes.
-        // Only when there's actually input, than hasError gets to be an effect
+        // Only when there's actually input, then hasError gets to be an effect
         if (hasError && hasValue) {
             setIsValidInputData(false);
         } else if (!hasValue && isRequired) {

--- a/src/app/components/molecules/Input/Input.tsx
+++ b/src/app/components/molecules/Input/Input.tsx
@@ -262,11 +262,13 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
         setIsValidInputData(validation);
     }, [inputDisplayValue, inputValue]);
 
+    // Consider a required, but empty input as valid for display purposes
+
     return (
         <>
             <StyledInput
                 className={className}
-                hasError={hasError || !isValidInputData}
+                hasError={hasError || (!isValidInputData && hasValue)}
                 isClickable={!isDisabled && Boolean(onClick)}
                 isDisabled={isDisabled}
                 isFocused={isFocused}
@@ -281,7 +283,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     as={isTextarea ? 'textarea' : 'input'}
                     autoFocus={autoFocus}
                     hasAdornment={adornment !== undefined}
-                    hasError={hasError || !isValidInputData}
+                    hasError={hasError || (!isValidInputData && hasValue)}
                     hasNegativeAmountColor={
                         hasNegativeAmountColor && !isEmpty(inputDisplayValue) && toNumber(inputDisplayValue) < 0
                     }
@@ -310,11 +312,12 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     <FormElementLabel
                         adornmentPosition={adornmentPosition}
                         hasAdornment={adornment !== undefined}
-                        hasError={hasError || !isValidInputData}
+                        hasError={hasError || (!isValidInputData && hasValue)}
                         isActive={hasValue}
                         isDisabled={isDisabled}
                         isFocused={isFocused}
                         isHovered={isHovered}
+                        isRequired={isRequired}
                         isValid={isValid}
                         variant={variant}
                     >
@@ -325,7 +328,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                 {adornment && (
                     <AdornmentWrapper
                         adornmentPosition={adornmentPosition}
-                        hasError={hasError || !isValidInputData}
+                        hasError={hasError || (!isValidInputData && hasValue)}
                         hasValue={hasValue}
                         isDisabled={isDisabled}
                         isFocused={isFocused}
@@ -337,7 +340,7 @@ export const Input: FunctionComponent<InputProps & { [key: string]: any }> = ({
                     </AdornmentWrapper>
                 )}
             </StyledInput>
-            {errorMessage && (hasError || !isValidInputData) && !isDisabled && (
+            {errorMessage && (hasError || (!isValidInputData && hasValue)) && !isDisabled && (
                 <ErrorMessage isOutlineVariant={variant === InputVariant.OUTLINE && !ignoreOutlineVariant}>
                     {errorMessage}
                 </ErrorMessage>

--- a/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.tsx
+++ b/src/app/components/molecules/SelectionControlGroup/SelectionControlGroup.tsx
@@ -9,6 +9,7 @@ import {
 import { FormElementLabel } from '../FormElementLabel/FormElementLabel';
 import { isEmpty } from '../../../utils/functions/validateFunctions';
 import Label from '../../atoms/Label/Label';
+import RequiredIndicator from '../../atoms/RequiredIndicator/RequiredIndicator';
 import SelectionControl from '../SelectionControl/SelectionControl';
 import { SelectionControlType } from '../SelectionControl/types';
 
@@ -70,12 +71,13 @@ export const SelectionControlGroup: FunctionComponent<SelectionControlGroupProps
     return (
         <SelectedControlGroupWrapper>
             {title && variant !== SelectionControlGroupVariant.COMPACT ? (
-                <FormElementLabel hasError={hasError} isDisabled={isDisabled}>
+                <FormElementLabel hasError={hasError} isDisabled={isDisabled} isRequired={isRequired}>
                     {title}
                 </FormElementLabel>
             ) : (
                 <Label hasError={hasError} isDisabled={isDisabled} isSmall>
                     {title}
+                    {isRequired && <RequiredIndicator isDisabled={isDisabled} />}
                 </Label>
             )}
             <StyledSelectionControlGroup

--- a/src/app/components/organisms/DatePicker/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/app/components/organisms/DatePicker/DateRangePicker/DateRangePicker.stories.tsx
@@ -29,6 +29,7 @@ export const Default: FunctionComponent = () => {
             isDayHighlighted={(day): boolean => day.day() === 1}
             isDisabled={boolean('Is disabled', false)}
             isOutsideRange={(): false => false}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect
             label={text('Label', 'Je favoriete periode')}
             minimumNights={number('Minimum nights', 1)}
@@ -103,6 +104,7 @@ export const DefaultWithoutShortcuts: FunctionComponent = () => {
             isDayHighlighted={(day): boolean => day.day() === 1}
             isDisabled={boolean('Is disabled', false)}
             isOutsideRange={(): false => false}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect
             label={text('Label', 'Je favoriete periode')}
             minimumNights={number('Minimum nights', 1)}
@@ -146,6 +148,7 @@ export const DefaultWithoutFooter: FunctionComponent = () => {
             isDayHighlighted={(day): boolean => day.day() === 1}
             isDisabled={boolean('Is disabled', false)}
             isOutsideRange={(): false => false}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect={boolean('Keep open on date select', true)}
             label={text('Label', 'Je favoriete periode')}
             minimumNights={number('Minimum nights', 1)}
@@ -210,6 +213,7 @@ export const WithYearSelector: FunctionComponent = () => {
             isDayBlocked={(day): boolean => day.day() === 1}
             isDayHighlighted={(day): boolean => day.day() === 3}
             isDisabled={boolean('Is disabled', false)}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect={boolean('Keep open on date select', true)}
             label={text('Label', 'Vakantie periode')}
             labelMonth={text('Label month', 'Maand')}

--- a/src/app/components/organisms/DatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/src/app/components/organisms/DatePicker/DateRangePicker/DateRangePicker.tsx
@@ -30,6 +30,7 @@ export interface DateRangePickerProps {
     isDayHighlighted?: (day: Moment) => boolean;
     isDisabled?: boolean;
     isOutsideRange?: (day: Moment) => boolean;
+    isRequired?: boolean;
     keepOpenOnDateSelect?: boolean;
     label: ReactNode;
     labelMonth?: ReactNode;
@@ -66,6 +67,7 @@ export const DateRangePicker: FunctionComponent<DateRangePickerProps> = ({
     isDayHighlighted,
     isDisabled = false,
     isOutsideRange,
+    isRequired = false,
     keepOpenOnDateSelect,
     label,
     labelMonth,
@@ -122,7 +124,13 @@ export const DateRangePicker: FunctionComponent<DateRangePickerProps> = ({
             }}
         >
             <StyledDateRangePicker>
-                <FormElementLabel isActive isDisabled={isDisabled} isFocused={isFocused} isHovered={isHovered}>
+                <FormElementLabel
+                    isActive
+                    isDisabled={isDisabled}
+                    isFocused={isFocused}
+                    isHovered={isHovered}
+                    isRequired={isRequired}
+                >
                     {label}
                 </FormElementLabel>
                 <AirbnbDateRangePicker

--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.stories.tsx
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.stories.tsx
@@ -22,6 +22,7 @@ export const Default: FunctionComponent = () => {
             isDayHighlighted={(day): boolean => day.day() === 6}
             isDisabled={boolean('Is disabled', false)}
             isFocused={isFocused}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect={boolean('Keep open on date select', true)}
             label={text('Label', 'Speeldatum')}
             numberOfMonths={number('Number of months', 1)}
@@ -57,6 +58,7 @@ export const DatePickerOpensUp: FunctionComponent = () => {
                 isDayHighlighted={(day): boolean => day.day() === 6}
                 isDisabled={boolean('Is disabled', false)}
                 isFocused={isFocused}
+                isRequired={boolean('Is required', false)}
                 keepOpenOnDateSelect={boolean('Keep open on date select', true)}
                 label={text('Label', 'Speeldatum')}
                 numberOfMonths={number('Number of months', 1)}
@@ -90,6 +92,7 @@ export const DatePickerAlignRight: FunctionComponent = () => {
                 displayFormat={text('Display format', 'ddd D MMM Y')}
                 id="datepicker"
                 isFocused={isFocused}
+                isRequired={boolean('Is required', false)}
                 keepOpenOnDateSelect={boolean('Keep open on date select', true)}
                 label={text('Label', 'Speeldatum')}
                 numberOfMonths={number('Number of months', 1)}
@@ -122,6 +125,7 @@ export const WithYearSelector: FunctionComponent = () => {
             isDisabled={boolean('Is disabled', false)}
             isFocused={isFocused}
             isOutsideRange={(day): boolean => day.isAfter(moment(), 'day')}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect={boolean('Keep open on date select', true)}
             label={text('Label', 'Geboortedatum')}
             labelMonth={text('Label month', 'Maand')}
@@ -158,6 +162,7 @@ export const WithFooter: FunctionComponent = () => {
             isDisabled={boolean('Is disabled', false)}
             isFocused={isFocused}
             isOutsideRange={(day): boolean => day.isAfter(moment(), 'day')}
+            isRequired={boolean('Is required', false)}
             keepOpenOnDateSelect={boolean('Keep open on date select', true)}
             label={text('Label', 'Geboortedatum')}
             labelMonth={text('Label month', 'Maand')}

--- a/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/src/app/components/organisms/DatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -36,6 +36,7 @@ export interface SingleDatePickerProps {
     isDisabled?: boolean;
     isFocused: boolean;
     isOutsideRange?: (day: Moment) => boolean;
+    isRequired?: boolean;
     keepOpenOnDateSelect?: boolean;
     label?: ReactNode;
     labelMonth?: ReactNode;
@@ -70,6 +71,7 @@ export const SingleDatePicker: FunctionComponent<SingleDatePickerProps> = ({
     isDisabled = false,
     isFocused,
     isOutsideRange,
+    isRequired = false,
     keepOpenOnDateSelect,
     label,
     labelMonth,
@@ -193,6 +195,7 @@ export const SingleDatePicker: FunctionComponent<SingleDatePickerProps> = ({
                                 isDisabled={isDisabled}
                                 isFocused={isFocused}
                                 isHovered={isHovered}
+                                isRequired={isRequired}
                                 variant={
                                     variant === SingleDatePickerVariant.OUTLINE
                                         ? InputVariant.OUTLINE

--- a/src/app/components/organisms/DropdownMultiSelect/DropdownMultiSelect.stories.tsx
+++ b/src/app/components/organisms/DropdownMultiSelect/DropdownMultiSelect.stories.tsx
@@ -75,6 +75,7 @@ const BaseComponent = <T extends DropdownMultiSelectOption>(
                 errorMessage={text('Error message', 'Everything is broken, oops')}
                 hasError={boolean('Has error', false)}
                 isDisabled={boolean('Is disabled', false)}
+                isRequired={boolean('Is required', false)}
                 isValid={boolean('Is valid', false)}
                 label={label}
                 maxHeight={number('Max height', 400)}

--- a/src/app/components/organisms/DropdownMultiSelect/DropdownMultiSelect.tsx
+++ b/src/app/components/organisms/DropdownMultiSelect/DropdownMultiSelect.tsx
@@ -35,6 +35,7 @@ export interface DropdownMultiSelectProps<T extends DropdownMultiSelectOption> {
     errorMessage?: ReactNode;
     hasError?: boolean;
     isDisabled?: boolean;
+    isRequired?: boolean;
     isValid?: boolean;
     label?: ReactNode;
     maxHeight?: number;
@@ -64,6 +65,7 @@ export const DropdownMultiSelect = <T extends DropdownMultiSelectOption>({
     errorMessage,
     hasError = false,
     isDisabled = false,
+    isRequired = false,
     isValid = false,
     label,
     maxHeight,
@@ -301,6 +303,7 @@ export const DropdownMultiSelect = <T extends DropdownMultiSelectOption>({
                     isDisabled={isDisabled}
                     isHovered={isHovered}
                     isOpen={isOpen}
+                    isRequired={isRequired}
                     isValid={isValid}
                     label={label}
                     name={name}

--- a/src/app/components/organisms/DropdownSelect/DropdownSelect.stories.tsx
+++ b/src/app/components/organisms/DropdownSelect/DropdownSelect.stories.tsx
@@ -35,6 +35,7 @@ export const Configurable: FunctionComponent = () => {
             hasError={boolean('Has error', false)}
             iconType={select('Type', IconType, IconType.CLUBPLACEHOLDER1)}
             isDisabled={boolean('Is disabled', false)}
+            isRequired={boolean('Is required', false)}
             isSearchAny={boolean('Is search any', false)}
             isValid={boolean('Is valid', false)}
             label={text('Label', 'This is a label')}

--- a/src/app/components/organisms/DropdownSelect/DropdownSelect.tsx
+++ b/src/app/components/organisms/DropdownSelect/DropdownSelect.tsx
@@ -30,6 +30,7 @@ export interface DropdownSelectProps<T extends DropdownSelectOption> {
     hasError?: boolean;
     iconType: IconType;
     isDisabled?: boolean;
+    isRequired?: boolean;
     isSearchAny?: boolean;
     isValid?: boolean;
     label?: ReactNode;
@@ -54,6 +55,7 @@ export const DropdownSelect = <T extends DropdownSelectOption>({
     iconType,
     footerText,
     isDisabled = false,
+    isRequired = false,
     isSearchAny = false,
     isValid = false,
     label,
@@ -186,6 +188,7 @@ export const DropdownSelect = <T extends DropdownSelectOption>({
                 errorMessage={errorMessage}
                 hasError={hasError}
                 isDisabled={isDisabled}
+                isRequired={isRequired}
                 isValid={isValid}
                 label={label}
                 name={name}

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE, REQUIRED_INDICATOR } from '../../../../../global/constants';
 import { Dropdown, DropdownOption, DropdownProps, DropdownVariant } from '../../../molecules/Dropdown';
 import { DropdownMultiSelect, DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { EditableDataComponent, InputType, InputVariant, Locale } from '../../../../types';
@@ -5,7 +6,6 @@ import { EditableInformationData, ScorePickerDataProps, ValueTypes } from '../ty
 import { generateDropdownSelectOptionLabel, getValueOfEditableDataComponent } from '../utils/informationDataFunctions';
 import { SingleDatePicker, SingleDatePickerVariant } from '../../DatePicker';
 import TimePicker, { TimePickerProps } from '../../../molecules/TimePicker/TimePicker';
-import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import DropdownSelect from '../../DropdownSelect/DropdownSelect';
 import { InformationTableProps } from '../../InformationTable';
 import Input from '../../../molecules/Input/Input';
@@ -55,6 +55,15 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
         .filter((dataInstance) => isBeingEdited || !dataInstance.isVisibleOnlyOnEdit)
         .map((dataInstance) => {
             const { isDisabled, isEditable, isRequired, label } = dataInstance;
+
+            const labelValue = isRequired ? (
+                <>
+                    {label} {REQUIRED_INDICATOR}
+                </>
+            ) : (
+                label
+            );
+
             let autoFocus = false;
 
             if (hasAutoFocus && !isFocusedInputSet && isEditable) {
@@ -70,6 +79,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
             ) {
                 return {
                     isDisabled,
+                    isRequired: isRequired || false,
                     isTextArea: dataInstance.component === EditableDataComponent.TEXTAREA,
                     label,
                     value: getValueOfEditableDataComponent(
@@ -87,7 +97,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.CHECKBOX) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <SelectionControl
                             errorMessage={dataInstance.errorMessage}
@@ -95,6 +105,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             hasVerticalCorrection
                             isChecked={values[name] as boolean}
                             isDisabled={isDisabled}
+                            isRequired={isRequired || false}
                             label={dataInstance.placeholder}
                             name={name}
                             onChange={(): void => {
@@ -108,7 +119,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.DATEPICKER) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <SingleDatePicker
                             date={values[name] as moment.Moment | null}
@@ -135,13 +146,14 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.DROPDOWN) {
                 return {
-                    label,
+                    label: labelValue,
                     textValue: dataInstance.textValue,
                     value: (
                         <Dropdown
                             errorMessage={dataInstance.errorMessage}
                             hasError={hasInputError || dataInstance.hasError}
                             isDisabled={isDisabled}
+                            isRequired={isRequired || false}
                             name={name}
                             onChange={({ currentTarget }): void => {
                                 onDropdownChange(
@@ -163,7 +175,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.DROPDOWNMULTISELECT) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <DropdownMultiSelect
                             allSelectedLabel={dataInstance.allSelectedLabel}
@@ -173,6 +185,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             errorMessage={dataInstance.errorMessage}
                             hasError={hasInputError || dataInstance.hasError}
                             isDisabled={isDisabled}
+                            isRequired={isRequired || false}
                             maxHeight={dataInstance.maxHeight}
                             minHeight={dataInstance.minHeight}
                             name={name}
@@ -188,7 +201,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.DROPDOWNSELECT) {
                 return {
-                    label,
+                    label: labelValue,
                     textValue: dataInstance.value,
                     value: (
                         <DropdownSelect
@@ -199,6 +212,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
                             hasError={hasInputError || dataInstance.hasError}
                             iconType={dataInstance.iconType}
                             isDisabled={isDisabled}
+                            isRequired={isRequired || false}
                             name={dataInstance.name}
                             noResultsMessage={dataInstance.noResultsMessage}
                             onChange={(option: T) => onDropdownChange(option, name, dataInstance.nameId)}
@@ -217,13 +231,14 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.INPUT) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <Input
                             autoFocus={autoFocus && (!hasError || !dataInstance.onBlur)}
                             errorMessage={dataInstance.errorMessage}
                             hasError={hasInputError || dataInstance.hasError}
                             isDisabled={isDisabled}
+                            isRequired={isRequired || false}
                             label={dataInstance.placeholder}
                             locale={locale}
                             maxLength={dataInstance.maxLength}
@@ -256,7 +271,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.INPUTCOLOR) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <InputColor
                             isDisabled={isDisabled}
@@ -272,7 +287,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.INPUTCURRENCY) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <InputCurrency
                             autoFocus={autoFocus && (!hasError || !dataInstance.onBlur)}
@@ -313,7 +328,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.INPUTNUMBER) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <Input
                             autoFocus={autoFocus && (!hasError || !dataInstance.onBlur)}
@@ -354,7 +369,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.SCOREPICKER) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <ScorePicker
                             autoFocus={autoFocus}
@@ -372,7 +387,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.TEXTAREA) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <Input
                             autoFocus={autoFocus && (!hasError || !dataInstance.onBlur)}
@@ -412,7 +427,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             if (dataInstance.component === EditableDataComponent.TIMEPICKER) {
                 return {
-                    label,
+                    label: labelValue,
                     value: (
                         <TimePicker
                             autoFocus={autoFocus}
@@ -428,7 +443,7 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
             }
 
             return {
-                label,
+                label: labelValue,
                 value: (
                     <Input
                         autoFocus={autoFocus}

--- a/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
+++ b/src/app/components/organisms/EditableInformation/editableData/editableData.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_LOCALE, REQUIRED_INDICATOR } from '../../../../../global/constants';
 import { Dropdown, DropdownOption, DropdownProps, DropdownVariant } from '../../../molecules/Dropdown';
 import { DropdownMultiSelect, DropdownMultiSelectOption } from '../../DropdownMultiSelect';
 import { EditableDataComponent, InputType, InputVariant, Locale } from '../../../../types';
@@ -6,6 +5,7 @@ import { EditableInformationData, ScorePickerDataProps, ValueTypes } from '../ty
 import { generateDropdownSelectOptionLabel, getValueOfEditableDataComponent } from '../utils/informationDataFunctions';
 import { SingleDatePicker, SingleDatePickerVariant } from '../../DatePicker';
 import TimePicker, { TimePickerProps } from '../../../molecules/TimePicker/TimePicker';
+import { DEFAULT_LOCALE } from '../../../../../global/constants';
 import DropdownSelect from '../../DropdownSelect/DropdownSelect';
 import { InformationTableProps } from '../../InformationTable';
 import Input from '../../../molecules/Input/Input';
@@ -13,6 +13,7 @@ import { InputColor } from '../../InputColor/InputColor';
 import InputCurrency from '../../InputCurrency/InputCurrency';
 import { isEmpty } from '../../../../utils/functions/validateFunctions';
 import React from 'react';
+import RequiredIndicator from '../../../atoms/RequiredIndicator/RequiredIndicator';
 import ScorePicker from '../../../molecules/ScorePicker/ScorePicker';
 import { SelectionControl } from '../../../molecules/SelectionControl';
 
@@ -58,7 +59,8 @@ export const editableData = <T extends DropdownOption, U extends DropdownMultiSe
 
             const labelValue = isRequired ? (
                 <>
-                    {label} {REQUIRED_INDICATOR}
+                    {label}
+                    <RequiredIndicator isDisabled={isDisabled} />
                 </>
             ) : (
                 label

--- a/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
+++ b/src/app/components/organisms/EditableInformation/utils/informationDataFunctions.tsx
@@ -36,7 +36,9 @@ import moment from 'moment';
 
 export const getStatus = (hasError: boolean, isLoading?: boolean, isDisabled?: boolean): Status => {
     if (hasError) {
-        return Status.INVALID;
+        // CW-1469: for now there seems to be no error state
+        // return Status.INVALID;
+        return Status.DEFAULT;
     }
 
     if (isLoading || isDisabled) {

--- a/src/app/components/organisms/InformationTable/InformationTable.tsx
+++ b/src/app/components/organisms/InformationTable/InformationTable.tsx
@@ -4,10 +4,12 @@ import { AmountOfColumns } from './types';
 import InformationErrors from './components/InformationErrors';
 import { InformationWarnings } from './components/InformationWarnings';
 import { isEmpty } from '../../../utils/functions/validateFunctions';
+import { REQUIRED_INDICATOR } from '../../../../global/constants';
 import { Skeleton } from '../../molecules/Skeleton/Skeleton';
 
 export interface InformationTableData {
     isDisabled?: boolean;
+    isRequired?: boolean;
     isTextArea?: boolean;
     label: ReactNode;
     value: ReactNode;
@@ -65,6 +67,7 @@ export const InformationTable: FunctionComponent<InformationTableProps> = ({
                         <Row key={index}>
                             <Label isDisabled={isDisabled} isTextArea={isTextArea || element.isTextArea || false}>
                                 {element.label}
+                                {element.isRequired && ` ${REQUIRED_INDICATOR}`}
                             </Label>
                             <Value
                                 isDisabled={isDisabled || element.isDisabled || false}

--- a/src/app/components/organisms/InformationTable/InformationTable.tsx
+++ b/src/app/components/organisms/InformationTable/InformationTable.tsx
@@ -4,7 +4,7 @@ import { AmountOfColumns } from './types';
 import InformationErrors from './components/InformationErrors';
 import { InformationWarnings } from './components/InformationWarnings';
 import { isEmpty } from '../../../utils/functions/validateFunctions';
-import { REQUIRED_INDICATOR } from '../../../../global/constants';
+import RequiredIndicator from '../../atoms/RequiredIndicator/RequiredIndicator';
 import { Skeleton } from '../../molecules/Skeleton/Skeleton';
 
 export interface InformationTableData {
@@ -67,7 +67,7 @@ export const InformationTable: FunctionComponent<InformationTableProps> = ({
                         <Row key={index}>
                             <Label isDisabled={isDisabled} isTextArea={isTextArea || element.isTextArea || false}>
                                 {element.label}
-                                {element.isRequired && ` ${REQUIRED_INDICATOR}`}
+                                {element.isRequired && <RequiredIndicator isDisabled={isDisabled} />}
                             </Label>
                             <Value
                                 isDisabled={isDisabled || element.isDisabled || false}

--- a/src/app/components/organisms/InputPassword/InputPassword.stories.tsx
+++ b/src/app/components/organisms/InputPassword/InputPassword.stories.tsx
@@ -13,6 +13,7 @@ export const Configurable: FunctionComponent = () => {
             errorMessage={text('Error message', 'Help, something went wrong!')}
             hasError={boolean('Has error', false)}
             isDisabled={boolean('Is disabled', false)}
+            isRequired={boolean('Is required', false)}
             isValid={boolean('Is valid', false)}
             label={text('Label', 'Your password')}
             maxLength={number('Max length', 100)}

--- a/src/app/components/organisms/InputPassword/InputPassword.tsx
+++ b/src/app/components/organisms/InputPassword/InputPassword.tsx
@@ -10,6 +10,7 @@ export interface InputPasswordProps {
     errorMessage?: ReactNode;
     hasError?: boolean;
     isDisabled?: boolean;
+    isRequired?: boolean;
     isValid?: boolean;
     isVisibleDefault?: boolean;
     label: ReactNode;
@@ -27,6 +28,7 @@ export const InputPassword: FunctionComponent<InputPasswordProps> = ({
     errorMessage,
     hasError = false,
     isDisabled = false,
+    isRequired = false,
     isValid = false,
     isVisibleDefault = false,
     label,
@@ -46,6 +48,7 @@ export const InputPassword: FunctionComponent<InputPasswordProps> = ({
                 errorMessage={errorMessage}
                 hasError={hasError}
                 isDisabled={isDisabled}
+                isRequired={isRequired}
                 isValid={isValid}
                 label={label}
                 maxLength={maxLength}

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -2,3 +2,4 @@ import { Locale } from '../app/types';
 
 export const DEFAULT_LOCALE = Locale.NL;
 export const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
+export const REQUIRED_INDICATOR = '*';


### PR DESCRIPTION
### Pull Request (PR) Dexels-ui-kit

After discussion with the designer, certain changes are made.
I've wanted to hang on to the disabled button while data is invalid, so that stays, but slightly different in display to make it less in your face for the user.
So red borders are no longer shown when data is required, but nothing has been set.
Ofcourse it should be red when data is invalid.

**Jira link**:
*https://jira.sportlink.nl/browse/CW-1469*

**Description of the pull request**:
*- display required indicator in Input, Dropdown, DropdownSelect, DropdownMultiselect, SelectionControlGroup and DatePickers*
*- display required indicator in both modes in EditableInformation*
*- in Input isRequired will not trigger invalid display when empty, also not when made empty (situations are handled the same)*
*- in EditableInformation isRequired still will be handled as invalid when empty so we can have the Save button disabled, but the error state is removed in both the panel and input fields*

<br />

- [ ] New component? Did you add it to the library exports file `src/lib/index.ts`?
- [ ] New iconfont? Update `selection.json`, `iconfont.css` (mind the path part) and the values in `src/app/types.ts`?

<br />

#### Feel free to ask if this PR template needs to be updated!
